### PR TITLE
Add 2025 race schedule and import enhancements

### DIFF
--- a/API/F1_API/app/Console/Commands/ImportRaces.php
+++ b/API/F1_API/app/Console/Commands/ImportRaces.php
@@ -4,6 +4,7 @@ namespace App\Console\Commands;
 
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\DB;
+use Carbon\Carbon;
 
 class ImportRaces extends Command
 {
@@ -34,10 +35,11 @@ class ImportRaces extends Command
             }
             $this->info('Număr curse în JSON: ' . count($races));
 
-            $date = now()->toDateTimeString(); // Fără dată în fișier, folosim data curentă
-            $status = 'upcoming';
+            $date = isset($race['date'])
+                ? Carbon::parse($race['date'])
+                : now();
+            $status = $date->isFuture() ? 'upcoming' : 'finished';
             $this->info("Saving race: " . $race['name']);
-
 
             DB::table('races')->updateOrInsert(
                 ['circuit_id' => $circuitId],

--- a/API/F1_API/database/migrations/2025_06_09_000000_add_circuit_id_to_races_table.php
+++ b/API/F1_API/database/migrations/2025_06_09_000000_add_circuit_id_to_races_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('races', function (Blueprint $table) {
+            $table->string('circuit_id')->unique()->after('id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('races', function (Blueprint $table) {
+            $table->dropColumn('circuit_id');
+        });
+    }
+};

--- a/API/F1_API/storage/app/.gitignore
+++ b/API/F1_API/storage/app/.gitignore
@@ -1,4 +1,6 @@
 *
 !private/
 !public/
+!data/
+!data/**
 !.gitignore

--- a/API/F1_API/storage/app/data/championships/f1-locations-2025.json
+++ b/API/F1_API/storage/app/data/championships/f1-locations-2025.json
@@ -1,0 +1,170 @@
+[
+  {
+    "id": "australian-grand-prix",
+    "name": "Australian Grand Prix",
+    "country": "Australia",
+    "location": "Albert Park Circuit, Melbourne",
+    "date": "2025-03-16"
+  },
+  {
+    "id": "chinese-grand-prix",
+    "name": "Chinese Grand Prix",
+    "country": "China",
+    "location": "Shanghai International Circuit, Shanghai",
+    "date": "2025-03-23"
+  },
+  {
+    "id": "japanese-grand-prix",
+    "name": "Japanese Grand Prix",
+    "country": "Japan",
+    "location": "Suzuka Circuit, Suzuka",
+    "date": "2025-04-06"
+  },
+  {
+    "id": "bahrain-grand-prix",
+    "name": "Bahrain Grand Prix",
+    "country": "Bahrain",
+    "location": "Bahrain International Circuit, Sakhir",
+    "date": "2025-04-13"
+  },
+  {
+    "id": "saudi-arabian-grand-prix",
+    "name": "Saudi Arabian Grand Prix",
+    "country": "Saudi Arabia",
+    "location": "Jeddah Corniche Circuit, Jeddah",
+    "date": "2025-04-20"
+  },
+  {
+    "id": "miami-grand-prix",
+    "name": "Miami Grand Prix",
+    "country": "United States",
+    "location": "Miami International Autodrome, Miami Gardens, Florida",
+    "date": "2025-05-04"
+  },
+  {
+    "id": "emilia-romagna-grand-prix",
+    "name": "Emilia Romagna Grand Prix",
+    "country": "Italy",
+    "location": "Imola Circuit, Imola",
+    "date": "2025-05-18"
+  },
+  {
+    "id": "monaco-grand-prix",
+    "name": "Monaco Grand Prix",
+    "country": "Monaco",
+    "location": "Circuit de Monaco, Monaco",
+    "date": "2025-05-25"
+  },
+  {
+    "id": "spanish-grand-prix",
+    "name": "Spanish Grand Prix",
+    "country": "Spain",
+    "location": "Circuit de Barcelona-Catalunya, Montmeló",
+    "date": "2025-06-01"
+  },
+  {
+    "id": "canadian-grand-prix",
+    "name": "Canadian Grand Prix",
+    "country": "Canada",
+    "location": "Circuit Gilles Villeneuve, Montreal",
+    "date": "2025-06-15"
+  },
+  {
+    "id": "austrian-grand-prix",
+    "name": "Austrian Grand Prix",
+    "country": "Austria",
+    "location": "Red Bull Ring, Spielberg",
+    "date": "2025-06-29"
+  },
+  {
+    "id": "british-grand-prix",
+    "name": "British Grand Prix",
+    "country": "United Kingdom",
+    "location": "Silverstone Circuit, Silverstone",
+    "date": "2025-07-06"
+  },
+  {
+    "id": "belgian-grand-prix",
+    "name": "Belgian Grand Prix",
+    "country": "Belgium",
+    "location": "Circuit de Spa-Francorchamps, Stavelot",
+    "date": "2025-07-27"
+  },
+  {
+    "id": "hungarian-grand-prix",
+    "name": "Hungarian Grand Prix",
+    "country": "Hungary",
+    "location": "Hungaroring, Mogyoród",
+    "date": "2025-08-03"
+  },
+  {
+    "id": "dutch-grand-prix",
+    "name": "Dutch Grand Prix",
+    "country": "Netherlands",
+    "location": "Circuit Zandvoort, Zandvoort",
+    "date": "2025-08-31"
+  },
+  {
+    "id": "italian-grand-prix",
+    "name": "Italian Grand Prix",
+    "country": "Italy",
+    "location": "Monza Circuit, Monza",
+    "date": "2025-09-07"
+  },
+  {
+    "id": "azerbaijan-grand-prix",
+    "name": "Azerbaijan Grand Prix",
+    "country": "Azerbaijan",
+    "location": "Baku City Circuit, Baku",
+    "date": "2025-09-21"
+  },
+  {
+    "id": "singapore-grand-prix",
+    "name": "Singapore Grand Prix",
+    "country": "Singapore",
+    "location": "Marina Bay Street Circuit, Singapore",
+    "date": "2025-10-05"
+  },
+  {
+    "id": "united-states-grand-prix",
+    "name": "United States Grand Prix",
+    "country": "United States",
+    "location": "Circuit of the Americas, Austin, Texas",
+    "date": "2025-10-19"
+  },
+  {
+    "id": "mexico-city-grand-prix",
+    "name": "Mexico City Grand Prix",
+    "country": "Mexico",
+    "location": "Autódromo Hermanos Rodríguez, Mexico City",
+    "date": "2025-10-26"
+  },
+  {
+    "id": "sao-paulo-grand-prix",
+    "name": "São Paulo Grand Prix",
+    "country": "Brazil",
+    "location": "Interlagos Circuit, São Paulo",
+    "date": "2025-11-09"
+  },
+  {
+    "id": "las-vegas-grand-prix",
+    "name": "Las Vegas Grand Prix",
+    "country": "United States",
+    "location": "Las Vegas Strip Circuit, Paradise, Nevada",
+    "date": "2025-11-22"
+  },
+  {
+    "id": "qatar-grand-prix",
+    "name": "Qatar Grand Prix",
+    "country": "Qatar",
+    "location": "Lusail International Circuit, Lusail",
+    "date": "2025-11-30"
+  },
+  {
+    "id": "abu-dhabi-grand-prix",
+    "name": "Abu Dhabi Grand Prix",
+    "country": "United Arab Emirates",
+    "location": "Yas Marina Circuit, Abu Dhabi",
+    "date": "2025-12-07"
+  }
+]


### PR DESCRIPTION
## Summary
- add 2025 championship race data for importing
- enhance race import command to use schedule date and set status
- add migration for circuit identifiers in races table

## Testing
- `php artisan test` *(fails: Could not open vendor/autoload.php)*

------
https://chatgpt.com/codex/tasks/task_e_689c9a05d0c88323ae839ecf24932e4a