### PR TITLE
Show ongoing races as In Progress

### DIFF
--- a/API/F1_API/app/Http/Controllers/RaceController.php
+++ b/API/F1_API/app/Http/Controllers/RaceController.php
@@ -5,33 +5,48 @@ namespace App\Http\Controllers;
 use App\Http\Requests\RaceRequest;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
+use Carbon\Carbon;
 
 class RaceController extends Controller
 {
     // API endpoint JSON
     public function apiIndex()
     {
-        $races = DB::table('races')->get();
+        $races = DB::table('races')->get()->map(fn($race) => $this->applyDynamicStatus($race));
         return response()->json($races);
     }
 
     // Pagina web cu listarea curselor
     public function index()
     {
-        $races = DB::table('races')->get();
+        $races = DB::table('races')->get()->map(fn($race) => $this->applyDynamicStatus($race));
         return view('races.index', compact('races'));
     }
 
     public function show(RaceRequest $id)
     {
-
         $race = DB::table('races')->find($id);
         if (!$race) abort(404);
+
+        $this->applyDynamicStatus($race);
 
         // Decodăm coordonatele circuitului, presupunem că sunt stocate JSON în coloana `coordinates`
         $coordinates = json_decode($race->coordinates);
 
         return view('races.show', compact('race', 'coordinates'));
+    }
+
+    private function applyDynamicStatus($race)
+    {
+        $now = Carbon::now();
+        $raceStart = Carbon::parse($race->date);
+
+        if (!in_array(strtolower($race->status), ['finished', 'cancelled']) &&
+            $now->between($raceStart, $raceStart->copy()->addHours(4))) {
+            $race->status = 'In Progress';
+        }
+
+        return $race;
     }
 }
 

--- a/API/F1_API/resources/views/races/index.blade.php
+++ b/API/F1_API/resources/views/races/index.blade.php
@@ -13,9 +13,9 @@
                 <p class="text-sm text-gray-600 dark:text-gray-400">Date: <span class="font-medium">{{ $race->date }}</span></p>
                 <p class="text-sm text-gray-600 dark:text-gray-400">Status:
                     <span class="font-semibold
-                        {{ $race->status === 'Finished' ? 'text-green-600 dark:text-green-400' : '' }}
-                        {{ $race->status === 'Cancelled' ? 'text-red-600 dark:text-red-400' : '' }}
-                        {{ $race->status !== 'Finished' && $race->status !== 'Cancelled' ? 'text-yellow-600 dark:text-yellow-400' : '' }}">
+                        {{ in_array(strtolower($race->status), ['finished', 'in progress']) ? 'text-green-600 dark:text-green-400' : '' }}
+                        {{ strtolower($race->status) === 'cancelled' ? 'text-red-600 dark:text-red-400' : '' }}
+                        {{ !in_array(strtolower($race->status), ['finished', 'in progress', 'cancelled']) ? 'text-yellow-600 dark:text-yellow-400' : '' }}">
                         {{ $race->status }}
                     </span>
                 </p>

--- a/API/F1_API/resources/views/races/show.blade.php
+++ b/API/F1_API/resources/views/races/show.blade.php
@@ -6,6 +6,14 @@
     </x-slot>
 
     <div class="container py-6">
+        <p class="mb-4 text-gray-600 dark:text-gray-400">Status:
+            <span class="font-semibold
+                {{ in_array(strtolower($race->status), ['finished', 'in progress']) ? 'text-green-600 dark:text-green-400' : '' }}
+                {{ strtolower($race->status) === 'cancelled' ? 'text-red-600 dark:text-red-400' : '' }}
+                {{ !in_array(strtolower($race->status), ['finished', 'in progress', 'cancelled']) ? 'text-yellow-600 dark:text-yellow-400' : '' }}">
+                {{ $race->status }}
+            </span>
+        </p>
         <canvas id="circuitCanvas" width="800" height="400" style="border:1px solid #ccc;"></canvas>
     </div>
 

--- a/F1App/F1App/RacesView.swift
+++ b/F1App/F1App/RacesView.swift
@@ -16,7 +16,9 @@ struct RacesView: View {
                     VStack(alignment: .leading) {
                         Text(race.location).font(.headline)
                         Text("Date: \(race.date)").font(.subheadline)
-                        Text("Status: \(race.status)").font(.caption).foregroundColor(.gray)
+                        Text("Status: \(race.status)")
+                            .font(.caption)
+                            .foregroundColor(statusColor(race.status))
                     }
                     .padding(8)
                 }
@@ -25,6 +27,17 @@ struct RacesView: View {
             .onAppear {
                 viewModel.fetchRaces()
             }
+        }
+    }
+
+    private func statusColor(_ status: String) -> Color {
+        switch status.lowercased() {
+        case "finished", "in progress":
+            return .green
+        case "cancelled":
+            return .red
+        default:
+            return .yellow
         }
     }
 }


### PR DESCRIPTION
## Summary
- Dynamically compute race status based on start time and mark ongoing events as `In Progress`
- Highlight in-progress races in green on web race list and detail views
- Colorize race status in the iOS app to match web behavior

## Testing
- `php artisan test` *(fails: vendor/autoload.php missing)*
- `composer install` *(fails: requires GitHub token)*
- `xcodebuild -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ca6b527888323923872a37a5b2dc1