### PR TITLE
Add year selection for historic races

### DIFF
--- a/API/F1_API/app/Http/Controllers/RaceController.php
+++ b/API/F1_API/app/Http/Controllers/RaceController.php
@@ -10,9 +10,19 @@ use Carbon\Carbon;
 class RaceController extends Controller
 {
     // API endpoint JSON
-    public function apiIndex()
+    public function apiIndex(Request $request)
     {
-        $races = DB::table('races')->get()->map(fn($race) => $this->applyDynamicStatus($race));
+        $query = DB::table('races');
+
+        if ($request->has('year')) {
+            $query->whereYear('date', $request->query('year'));
+        }
+
+        if ($request->has('circuit_id')) {
+            $query->where('circuit_id', $request->query('circuit_id'));
+        }
+
+        $races = $query->get()->map(fn($race) => $this->applyDynamicStatus($race));
         return response()->json($races);
     }
 

--- a/F1App/F1App/HistoricRaceView.swift
+++ b/F1App/F1App/HistoricRaceView.swift
@@ -2,7 +2,10 @@ import SwiftUI
 
 struct HistoricRaceView: View {
     let coordinatesJSON: String?
-    let lastHeldDate: String
+    let circuitId: String
+
+    @State private var selectedYear = Calendar.current.component(.year, from: Date())
+    @StateObject private var viewModel = HistoricRaceViewModel()
 
     // MARK: - Nested Models
     struct Driver: Identifiable {
@@ -92,7 +95,18 @@ struct HistoricRaceView: View {
     // MARK: - Body
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {
-            Text("Last held on: \(lastHeldDate)")
+            Picker("Year", selection: $selectedYear) {
+                ForEach((1950...Calendar.current.component(.year, from: Date())).reversed(), id: \.self) {
+                    Text("\($0)").tag($0)
+                }
+            }
+            .pickerStyle(MenuPickerStyle())
+            .frame(maxWidth: .infinity, alignment: .center)
+            .onChange(of: selectedYear) { year in
+                viewModel.fetchRace(circuitId: circuitId, year: year)
+            }
+
+            Text("Last held on: \(viewModel.race?.date ?? "-")")
                 .font(.headline)
                 .frame(maxWidth: .infinity, alignment: .center)
 
@@ -157,6 +171,9 @@ struct HistoricRaceView: View {
         .sheet(item: $selectedDriver) { driver in
             DriverDetailCard(driver: driver)
         }
+        .onAppear {
+            viewModel.fetchRace(circuitId: circuitId, year: selectedYear)
+        }
     }
 }
 
@@ -191,6 +208,6 @@ struct DriverDetailCard: View {
 }
 
 #Preview {
-    HistoricRaceView(coordinatesJSON: "[[0,0],[1,0],[1,1],[0,1]]", lastHeldDate: "2024-05-12")
+    HistoricRaceView(coordinatesJSON: "[[0,0],[1,0],[1,1],[0,1]]", circuitId: "demo")
 }
 

--- a/F1App/F1App/HistoricRaceViewModel.swift
+++ b/F1App/F1App/HistoricRaceViewModel.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+class HistoricRaceViewModel: ObservableObject {
+    @Published var race: Race?
+
+    func fetchRace(circuitId: String, year: Int) {
+        guard let url = URL(string: "http://localhost:8000/api/races?year=\(year)&circuit_id=\(circuitId)") else { return }
+
+        URLSession.shared.dataTask(with: url) { data, response, error in
+            if let data = data {
+                if let decoded = try? JSONDecoder().decode([Race].self, from: data) {
+                    DispatchQueue.main.async {
+                        self.race = decoded.first
+                    }
+                }
+            } else if let error = error {
+                print("Error fetching historic race:", error)
+            }
+        }.resume()
+    }
+}

--- a/F1App/F1App/RaceDetailView.swift
+++ b/F1App/F1App/RaceDetailView.swift
@@ -32,7 +32,7 @@ struct RaceDetailView: View {
             } else if selectedTab == 1 {
                 Text("Section 2 content").font(.title)
             } else {
-                HistoricRaceView(coordinatesJSON: race.coordinates, lastHeldDate: race.date)
+                HistoricRaceView(coordinatesJSON: race.coordinates, circuitId: race.circuit_id ?? "")
             }
             
             Spacer()


### PR DESCRIPTION
## Summary
- allow `/api/races` endpoint to filter by year and circuit
- add HistoricRaceViewModel and year picker to choose race year
- wire new picker into race detail view

## Testing
- `php artisan test` *(fails: Failed opening required 'vendor/autoload.php')*
- `swiftc Models/Race.swift HistoricRaceViewModel.swift -o /tmp/historic_race_vm` *(fails: cannot find type 'ObservableObject' in scope)*

------
https://chatgpt.com/codex/tasks/task_e_689cbd02e0048323857c1913474d6969