### PR TITLE
Refresh historic race data on year change

### DIFF
--- a/F1App/F1App/HistoricRaceView.swift
+++ b/F1App/F1App/HistoricRaceView.swift
@@ -58,7 +58,7 @@ struct HistoricRaceView: View {
     // MARK: - Helpers
     func parseCoordinates() -> [CGPoint] {
         guard
-            let jsonString = coordinatesJSON,
+            let jsonString = viewModel.race?.coordinates ?? coordinatesJSON,
             let data = jsonString.data(using: .utf8),
             let arr = try? JSONSerialization.jsonObject(with: data) as? [[Double]]
         else {

--- a/F1App/F1App/HistoricRaceViewModel.swift
+++ b/F1App/F1App/HistoricRaceViewModel.swift
@@ -7,14 +7,17 @@ class HistoricRaceViewModel: ObservableObject {
         guard let url = URL(string: "http://localhost:8000/api/races?year=\(year)&circuit_id=\(circuitId)") else { return }
 
         URLSession.shared.dataTask(with: url) { data, response, error in
-            if let data = data {
-                if let decoded = try? JSONDecoder().decode([Race].self, from: data) {
-                    DispatchQueue.main.async {
-                        self.race = decoded.first
-                    }
-                }
-            } else if let error = error {
-                print("Error fetching historic race:", error)
+            guard error == nil, let data = data else {
+                DispatchQueue.main.async { self.race = nil }
+                if let error = error { print("Error fetching historic race:", error) }
+                return
+            }
+
+            if let decoded = try? JSONDecoder().decode([Race].self, from: data),
+               let race = decoded.first {
+                DispatchQueue.main.async { self.race = race }
+            } else {
+                DispatchQueue.main.async { self.race = nil }
             }
         }.resume()
     }


### PR DESCRIPTION
## Summary
- Ensure historic race fetch clears stale data and handles errors
- Parse track coordinates from fetched race so circuit reflects selected year

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_689cc008dc288323bae791b54455244c