### PR TITLE
Add year picker and OpenF1 race loading

### DIFF
--- a/F1App/F1App/HistoricRaceView.swift
+++ b/F1App/F1App/HistoricRaceView.swift
@@ -142,7 +142,7 @@ struct HistoricRaceView: View {
                 }
                 .frame(height: 250)
 
-                Button(isAnimating ? "Stop Race Replay" : "Start Race Replay") {
+                Button(isAnimating ? "Stop Race" : "Start Race") {
                     if isAnimating {
                         stopAnimation()
                     } else {

--- a/F1App/F1App/RaceViewModel.swift
+++ b/F1App/F1App/RaceViewModel.swift
@@ -10,15 +10,45 @@ import Combine
 
 class RacesViewModel: ObservableObject {
     @Published var races = [Race]()
-    
-    func fetchRaces() {
-        guard let url = URL(string: "http://localhost:8000/api/races") else { return }
-        
+
+    struct OpenF1Meeting: Decodable {
+        let meeting_key: Int
+        let circuit_short_name: String?
+        let location: String
+        let meeting_name: String
+        let date_start: String
+    }
+
+    func fetchRaces(year: Int) {
+        guard let url = URL(string: "https://api.openf1.org/v1/meetings?year=\(year)") else { return }
+
         URLSession.shared.dataTask(with: url) { data, response, error in
             if let data = data {
-                if let decoded = try? JSONDecoder().decode([Race].self, from: data) {
+                if let decoded = try? JSONDecoder().decode([OpenF1Meeting].self, from: data) {
+                    let formatter = ISO8601DateFormatter()
+                    let now = Date()
+                    let races = decoded
+                        .filter { $0.meeting_name.contains("Grand Prix") }
+                        .map { meeting -> Race in
+                            let dateString = String(meeting.date_start.prefix(10))
+                            let status: String
+                            if let date = formatter.date(from: meeting.date_start) {
+                                status = date < now ? "finished" : "upcoming"
+                            } else {
+                                status = "unknown"
+                            }
+                            return Race(
+                                id: meeting.meeting_key,
+                                name: meeting.meeting_name,
+                                circuit_id: meeting.circuit_short_name,
+                                location: meeting.location,
+                                date: dateString,
+                                status: status,
+                                coordinates: nil
+                            )
+                        }
                     DispatchQueue.main.async {
-                        self.races = decoded
+                        self.races = races
                     }
                 } else {
                     print("Decoding failed")

--- a/F1App/F1App/RacesView.swift
+++ b/F1App/F1App/RacesView.swift
@@ -8,24 +8,39 @@ import SwiftUI
 
 struct RacesView: View {
     @StateObject private var viewModel = RacesViewModel()
-    
+    @State private var selectedYear = Calendar.current.component(.year, from: Date())
+
     var body: some View {
         NavigationView {
-            List(viewModel.races) { race in
-                NavigationLink(destination: RaceDetailView(race: race)) {
-                    VStack(alignment: .leading) {
-                        Text(race.location).font(.headline)
-                        Text("Date: \(race.date)").font(.subheadline)
-                        Text("Status: \(race.status)")
-                            .font(.caption)
-                            .foregroundColor(statusColor(race.status))
+            VStack {
+                Picker("Year", selection: $selectedYear) {
+                    ForEach((1950...Calendar.current.component(.year, from: Date())).reversed(), id: \.self) {
+                        Text("\($0)").tag($0)
                     }
-                    .padding(8)
+                }
+                .pickerStyle(MenuPickerStyle())
+
+                Button("Start Race") {
+                    viewModel.fetchRaces(year: selectedYear)
+                }
+                .buttonStyle(.borderedProminent)
+
+                List(viewModel.races) { race in
+                    NavigationLink(destination: RaceDetailView(race: race)) {
+                        VStack(alignment: .leading) {
+                            Text(race.location).font(.headline)
+                            Text("Date: \(race.date)").font(.subheadline)
+                            Text("Status: \(race.status)")
+                                .font(.caption)
+                                .foregroundColor(statusColor(race.status))
+                        }
+                        .padding(8)
+                    }
                 }
             }
-            .navigationTitle("F1 Circuits")
+            .navigationTitle("F1 Races")
             .onAppear {
-                viewModel.fetchRaces()
+                viewModel.fetchRaces(year: selectedYear)
             }
         }
     }


### PR DESCRIPTION
## Summary
- Load season data from OpenF1 after choosing a year
- Allow users to trigger fetching via a Start Race button
- Rename historic race replay control to Start Race

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_689cd5b540508323b56abc164df05d0c