### PR TITLE
Add basic race replay section with year selection

### DIFF
--- a/F1App/F1App/RaceDetailView.swift
+++ b/F1App/F1App/RaceDetailView.swift
@@ -25,15 +25,15 @@ struct RaceDetailView: View {
             
             Spacer()
             
-            if selectedTab == 0 {
-                CircuitView(coordinatesJSON: race.coordinates)
-                    .frame(height: UIScreen.main.bounds.height / 2)
-                    .padding()
-            } else if selectedTab == 1 {
-                Text("Section 2 content").font(.title)
-            } else {
-                Text("Section 3 content").font(.title)
-            }
+        if selectedTab == 0 {
+            CircuitView(coordinatesJSON: race.coordinates)
+                .frame(height: UIScreen.main.bounds.height / 2)
+                .padding()
+        } else if selectedTab == 1 {
+            Text("Section 2 content").font(.title)
+        } else {
+            RaceReplayView(race: race)
+        }
             
             Spacer()
         }

--- a/F1App/F1App/RaceReplayView.swift
+++ b/F1App/F1App/RaceReplayView.swift
@@ -1,0 +1,89 @@
+import SwiftUI
+
+struct Driver: Identifiable {
+    let id = UUID()
+    let initials: String
+    let teamColor: Color
+}
+
+struct RaceReplayView: View {
+    let race: Race
+    @State private var inputYear: String = ""
+    @State private var showRace: Bool = false
+
+    private var raceYear: String {
+        String(race.date.prefix(4))
+    }
+
+    private let sampleDrivers: [Driver] = [
+        Driver(initials: "HAM", teamColor: .gray),
+        Driver(initials: "VER", teamColor: .blue),
+        Driver(initials: "LEC", teamColor: .red),
+        Driver(initials: "NOR", teamColor: .orange)
+    ]
+
+    var body: some View {
+        VStack {
+            TextField("Enter year", text: $inputYear)
+                .keyboardType(.numberPad)
+                .padding()
+                .textFieldStyle(RoundedBorderTextFieldStyle())
+
+            Button("Load Race") {
+                showRace = (inputYear == raceYear)
+            }
+            .padding(.bottom)
+
+            if showRace {
+                CircuitView(coordinatesJSON: race.coordinates)
+                    .frame(height: 200)
+                    .padding(.bottom)
+
+                Button("Start") {
+                    // TODO: Implement race start logic
+                }
+                .padding(.bottom)
+
+                DriverCirclesView(drivers: sampleDrivers)
+                    .padding(.bottom)
+
+                WeatherInfoView()
+            } else if !inputYear.isEmpty {
+                Text("No race for selected year").foregroundColor(.red)
+            }
+        }
+        .padding()
+    }
+}
+
+struct DriverCirclesView: View {
+    let drivers: [Driver]
+
+    var body: some View {
+        HStack(spacing: 16) {
+            ForEach(drivers) { driver in
+                VStack {
+                    Circle()
+                        .fill(driver.teamColor)
+                        .frame(width: 24, height: 24)
+                    Text(driver.initials)
+                        .font(.caption)
+                }
+            }
+        }
+    }
+}
+
+struct WeatherInfoView: View {
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text("Temperature: --°C")
+            Text("Wind: -- km/h")
+            Text("Precipitation: --")
+            Text("Best Lap: --")
+            Text("Disqualified: --")
+        }
+        .font(.footnote)
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}


### PR DESCRIPTION
## Summary
- integrate new race replay view in race details
- show year selection, circuit drawing, start button and driver placeholders

## Testing
- `swiftc -typecheck RaceReplayView.swift RaceDetailView.swift CircuitView.swift Models/Race.swift` *(fails: no such module 'SwiftUI')*


------
https://chatgpt.com/codex/tasks/task_e_689cdaf4236c8323812886f4fae50975