### PR TITLE
Use OpenF1 circuit keys for races

### DIFF
--- a/API/F1_API/app/Console/Commands/ImportRaces.php
+++ b/API/F1_API/app/Console/Commands/ImportRaces.php
@@ -19,8 +19,9 @@ class ImportRaces extends Command
         $races = json_decode(file_get_contents($jsonPath), true);
 
         foreach ($races as $race) {
-            $circuitId = $race['id']; // ex: it-1922
-            $geoJsonPath = storage_path("app/data/circuits/{$circuitId}.geojson");
+            $circuitSlug = $race['id'];
+            $circuitId = $race['circuit_key']; // numeric OpenF1 circuit key
+            $geoJsonPath = storage_path("app/data/circuits/{$circuitSlug}.geojson");
 
             $coordinates = null;
             if (file_exists($geoJsonPath)) {
@@ -28,10 +29,10 @@ class ImportRaces extends Command
                     $geoData = json_decode(file_get_contents($geoJsonPath), true);
                     $coordinates = json_encode($geoData['features'][0]['geometry']['coordinates']);
                 } catch (\Exception $e) {
-                    $this->warn("Eroare la procesarea coordonatelor pentru {$circuitId}");
+                $this->warn("Eroare la procesarea coordonatelor pentru {$circuitSlug}");
                 }
             } else {
-                $this->warn("Fișierul GEOJSON lipsește pentru {$circuitId}");
+                $this->warn("Fișierul GEOJSON lipsește pentru {$circuitSlug}");
             }
             $this->info('Număr curse în JSON: ' . count($races));
 

--- a/API/F1_API/storage/app/data/championships/f1-locations-2025.json
+++ b/API/F1_API/storage/app/data/championships/f1-locations-2025.json
@@ -4,167 +4,191 @@
     "name": "Australian Grand Prix",
     "country": "Australia",
     "location": "Albert Park Circuit, Melbourne",
-    "date": "2025-03-16"
+    "date": "2025-03-16",
+    "circuit_key": 10
   },
   {
     "id": "chinese-grand-prix",
     "name": "Chinese Grand Prix",
     "country": "China",
     "location": "Shanghai International Circuit, Shanghai",
-    "date": "2025-03-23"
+    "date": "2025-03-23",
+    "circuit_key": 49
   },
   {
     "id": "japanese-grand-prix",
     "name": "Japanese Grand Prix",
     "country": "Japan",
     "location": "Suzuka Circuit, Suzuka",
-    "date": "2025-04-06"
+    "date": "2025-04-06",
+    "circuit_key": 46
   },
   {
     "id": "bahrain-grand-prix",
     "name": "Bahrain Grand Prix",
     "country": "Bahrain",
     "location": "Bahrain International Circuit, Sakhir",
-    "date": "2025-04-13"
+    "date": "2025-04-13",
+    "circuit_key": 63
   },
   {
     "id": "saudi-arabian-grand-prix",
     "name": "Saudi Arabian Grand Prix",
     "country": "Saudi Arabia",
     "location": "Jeddah Corniche Circuit, Jeddah",
-    "date": "2025-04-20"
+    "date": "2025-04-20",
+    "circuit_key": 149
   },
   {
     "id": "miami-grand-prix",
     "name": "Miami Grand Prix",
     "country": "United States",
     "location": "Miami International Autodrome, Miami Gardens, Florida",
-    "date": "2025-05-04"
+    "date": "2025-05-04",
+    "circuit_key": 151
   },
   {
     "id": "emilia-romagna-grand-prix",
     "name": "Emilia Romagna Grand Prix",
     "country": "Italy",
     "location": "Imola Circuit, Imola",
-    "date": "2025-05-18"
+    "date": "2025-05-18",
+    "circuit_key": 6
   },
   {
     "id": "monaco-grand-prix",
     "name": "Monaco Grand Prix",
     "country": "Monaco",
     "location": "Circuit de Monaco, Monaco",
-    "date": "2025-05-25"
+    "date": "2025-05-25",
+    "circuit_key": 22
   },
   {
     "id": "spanish-grand-prix",
     "name": "Spanish Grand Prix",
     "country": "Spain",
     "location": "Circuit de Barcelona-Catalunya, Montmeló",
-    "date": "2025-06-01"
+    "date": "2025-06-01",
+    "circuit_key": 15
   },
   {
     "id": "canadian-grand-prix",
     "name": "Canadian Grand Prix",
     "country": "Canada",
     "location": "Circuit Gilles Villeneuve, Montreal",
-    "date": "2025-06-15"
+    "date": "2025-06-15",
+    "circuit_key": 23
   },
   {
     "id": "austrian-grand-prix",
     "name": "Austrian Grand Prix",
     "country": "Austria",
     "location": "Red Bull Ring, Spielberg",
-    "date": "2025-06-29"
+    "date": "2025-06-29",
+    "circuit_key": 19
   },
   {
     "id": "british-grand-prix",
     "name": "British Grand Prix",
     "country": "United Kingdom",
     "location": "Silverstone Circuit, Silverstone",
-    "date": "2025-07-06"
+    "date": "2025-07-06",
+    "circuit_key": 2
   },
   {
     "id": "belgian-grand-prix",
     "name": "Belgian Grand Prix",
     "country": "Belgium",
     "location": "Circuit de Spa-Francorchamps, Stavelot",
-    "date": "2025-07-27"
+    "date": "2025-07-27",
+    "circuit_key": 7
   },
   {
     "id": "hungarian-grand-prix",
     "name": "Hungarian Grand Prix",
     "country": "Hungary",
     "location": "Hungaroring, Mogyoród",
-    "date": "2025-08-03"
+    "date": "2025-08-03",
+    "circuit_key": 4
   },
   {
     "id": "dutch-grand-prix",
     "name": "Dutch Grand Prix",
     "country": "Netherlands",
     "location": "Circuit Zandvoort, Zandvoort",
-    "date": "2025-08-31"
+    "date": "2025-08-31",
+    "circuit_key": 55
   },
   {
     "id": "italian-grand-prix",
     "name": "Italian Grand Prix",
     "country": "Italy",
     "location": "Monza Circuit, Monza",
-    "date": "2025-09-07"
+    "date": "2025-09-07",
+    "circuit_key": 39
   },
   {
     "id": "azerbaijan-grand-prix",
     "name": "Azerbaijan Grand Prix",
     "country": "Azerbaijan",
     "location": "Baku City Circuit, Baku",
-    "date": "2025-09-21"
+    "date": "2025-09-21",
+    "circuit_key": 144
   },
   {
     "id": "singapore-grand-prix",
     "name": "Singapore Grand Prix",
     "country": "Singapore",
     "location": "Marina Bay Street Circuit, Singapore",
-    "date": "2025-10-05"
+    "date": "2025-10-05",
+    "circuit_key": 61
   },
   {
     "id": "united-states-grand-prix",
     "name": "United States Grand Prix",
     "country": "United States",
     "location": "Circuit of the Americas, Austin, Texas",
-    "date": "2025-10-19"
+    "date": "2025-10-19",
+    "circuit_key": 9
   },
   {
     "id": "mexico-city-grand-prix",
     "name": "Mexico City Grand Prix",
     "country": "Mexico",
     "location": "Autódromo Hermanos Rodríguez, Mexico City",
-    "date": "2025-10-26"
+    "date": "2025-10-26",
+    "circuit_key": 65
   },
   {
     "id": "sao-paulo-grand-prix",
     "name": "São Paulo Grand Prix",
     "country": "Brazil",
     "location": "Interlagos Circuit, São Paulo",
-    "date": "2025-11-09"
+    "date": "2025-11-09",
+    "circuit_key": 14
   },
   {
     "id": "las-vegas-grand-prix",
     "name": "Las Vegas Grand Prix",
     "country": "United States",
     "location": "Las Vegas Strip Circuit, Paradise, Nevada",
-    "date": "2025-11-22"
+    "date": "2025-11-22",
+    "circuit_key": 152
   },
   {
     "id": "qatar-grand-prix",
     "name": "Qatar Grand Prix",
     "country": "Qatar",
     "location": "Lusail International Circuit, Lusail",
-    "date": "2025-11-30"
+    "date": "2025-11-30",
+    "circuit_key": 150
   },
   {
     "id": "abu-dhabi-grand-prix",
     "name": "Abu Dhabi Grand Prix",
     "country": "United Arab Emirates",
     "location": "Yas Marina Circuit, Abu Dhabi",
-    "date": "2025-12-07"
+    "date": "2025-12-07",
+    "circuit_key": 70
   }
 ]

--- a/F1App/F1App/HistoricalRaceView.swift
+++ b/F1App/F1App/HistoricalRaceView.swift
@@ -15,7 +15,7 @@ struct HistoricalRaceView: View {
             .pickerStyle(SegmentedPickerStyle())
             .padding(.horizontal)
             .onChange(of: viewModel.selectedYear) { year in
-                Task { await viewModel.fetchMeeting(for: year, circuitKey: race.circuit_id ?? "") }
+                Task { await viewModel.fetchMeeting(for: year, circuitId: race.circuit_id) }
             }
 
             if viewModel.isLoading {
@@ -80,7 +80,7 @@ struct HistoricalRaceView: View {
         }
         .onAppear {
             viewModel.loadYears()
-            Task { await viewModel.fetchMeeting(for: viewModel.selectedYear, circuitKey: race.circuit_id ?? "") }
+            Task { await viewModel.fetchMeeting(for: viewModel.selectedYear, circuitId: race.circuit_id) }
         }
         .sheet(item: $selectedDriver) { driver in
             DriverHistoricalDetailView(driver: driver, meetingKey: viewModel.meetingKey ?? 0)

--- a/F1App/F1App/HistoricalRaceViewModel.swift
+++ b/F1App/F1App/HistoricalRaceViewModel.swift
@@ -67,14 +67,14 @@ class HistoricalRaceViewModel: ObservableObject {
         availableYears = Array((currentYear-5)...currentYear).reversed()
     }
 
-    func fetchMeeting(for year: Int, circuitKey: String) async {
-        guard !circuitKey.isEmpty else { return }
+    func fetchMeeting(for year: Int, circuitId: Int?) async {
+        guard let circuitId = circuitId else { return }
         isLoading = true
         defer { isLoading = false }
         meetingKey = nil
         drivers = []
         errorMessage = nil
-        let urlString = "https://api.openf1.org/v1/meetings?year=\(year)&circuit_key=\(circuitKey)"
+        let urlString = "https://api.openf1.org/v1/meetings?year=\(year)&circuit_key=\(circuitId)"
         guard let url = URL(string: urlString) else { return }
         do {
             let (data, _) = try await URLSession.shared.data(from: url)

--- a/F1App/F1App/Models/Race.swift
+++ b/F1App/F1App/Models/Race.swift
@@ -8,7 +8,7 @@
 struct Race: Identifiable, Decodable {
     let id: Int
     let name: String
-    let circuit_id: String?
+    let circuit_id: Int?
     let location: String
     let date: String
     let status: String


### PR DESCRIPTION
## Summary
- add `circuit_key` to each 2025 race entry
- import races with numeric OpenF1 circuit key
- treat circuit ids as Int in app and request meetings by circuit key

## Testing
- `jq empty API/F1_API/storage/app/data/championships/f1-locations-2025.json`
- `php -l API/F1_API/app/Console/Commands/ImportRaces.php`
- `swiftc -typecheck F1App/F1App/Models/Race.swift`
- `swiftc -typecheck F1App/F1App/HistoricalRaceViewModel.swift` *(fails: no such module 'SwiftUI')*
- `swiftc -typecheck F1App/F1App/HistoricalRaceView.swift` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_689ce32104e883238a40fbd8a1d632ce