### PR TITLE
Add historical race simulation view

### DIFF
--- a/F1App/F1App/CircuitView.swift
+++ b/F1App/F1App/CircuitView.swift
@@ -9,57 +9,117 @@ import SwiftUI
 
 struct CircuitView: View {
     let coordinatesJSON: String?
-    
-    // Structură simplificată pentru un punct
-    struct Point: Identifiable {
-        let id = UUID()
-        let x: Double
-        let y: Double
+    let drivers: [DriverInfo]
+    let driverPositions: [Int: LocationPoint]
+
+    init(coordinatesJSON: String?, drivers: [DriverInfo] = [], driverPositions: [Int: LocationPoint] = [:]) {
+        self.coordinatesJSON = coordinatesJSON
+        self.drivers = drivers
+        self.driverPositions = driverPositions
     }
-    
-    // Convertim coordonatele geo în puncte relative pentru desen
-    func parseCoordinates() -> [CGPoint] {
+
+    // Parse track coordinates and compute bounds
+    func parseTrack() -> ([CGPoint], CGRect) {
         guard
             let jsonString = coordinatesJSON,
             let data = jsonString.data(using: .utf8),
-            let arr = try? JSONSerialization.jsonObject(with: data) as? [[Double]]
+            let arr = try? JSONSerialization.jsonObject(with: data) as? [[Double]],
+            !arr.isEmpty
         else {
-            return []
+            return ([], .zero)
         }
-        
-        // Coordonatele originale pot fi mari sau mici, vrem să le mapăm la un spațiu de desen
-        let lons = arr.map { $0[0] }
-        let lats = arr.map { $0[1] }
-        
-        guard let minLon = lons.min(), let maxLon = lons.max(),
-              let minLat = lats.min(), let maxLat = lats.max() else {
-            return []
-        }
-        
-        // Mapăm la un dreptunghi 0..1 (normalizare)
-        return arr.map { point in
-            let x = (point[0] - minLon) / (maxLon - minLon)
-            let y = 1 - (point[1] - minLat) / (maxLat - minLat) // inversăm y să fie corect sus-jos
+
+        let xs = arr.map { $0[0] }
+        let ys = arr.map { $0[1] }
+        let minX = xs.min() ?? 0
+        let maxX = xs.max() ?? 1
+        let minY = ys.min() ?? 0
+        let maxY = ys.max() ?? 1
+        let bounds = CGRect(x: minX, y: minY, width: maxX - minX, height: maxY - minY)
+
+        let points = arr.map { point in
+            let x = (point[0] - minX) / (maxX - minX)
+            let y = 1 - (point[1] - minY) / (maxY - minY)
             return CGPoint(x: x, y: y)
         }
+
+        return (points, bounds)
     }
-    
+
+    func locationTransform(trackBounds: CGRect) -> CGAffineTransform? {
+        let locs = Array(driverPositions.values)
+        guard !locs.isEmpty,
+              trackBounds.width > 0, trackBounds.height > 0 else { return nil }
+
+        let xs = locs.map { $0.x }
+        let ys = locs.map { $0.y }
+        guard let minX = xs.min(), let maxX = xs.max(),
+              let minY = ys.min(), let maxY = ys.max(),
+              maxX - minX > 0, maxY - minY > 0 else { return nil }
+
+        let locBounds = CGRect(x: minX, y: minY, width: maxX - minX, height: maxY - minY)
+        let trackCenter = CGPoint(x: trackBounds.midX, y: trackBounds.midY)
+        let locCenter = CGPoint(x: locBounds.midX, y: locBounds.midY)
+        let trackVector = CGPoint(x: trackBounds.maxX - trackBounds.minX,
+                                  y: trackBounds.maxY - trackBounds.minY)
+        let locVector = CGPoint(x: locBounds.maxX - locBounds.minX,
+                                y: locBounds.maxY - locBounds.minY)
+        let trackAngle = atan2(trackVector.y, trackVector.x)
+        let locAngle = atan2(locVector.y, locVector.x)
+        let rotation = trackAngle - locAngle
+        let scaleX = trackBounds.width / locBounds.width
+        let scaleY = trackBounds.height / locBounds.height
+        let scale = (scaleX + scaleY) / 2
+
+        var t = CGAffineTransform.identity
+        t = t.translatedBy(x: -locCenter.x, y: -locCenter.y)
+        t = t.rotated(by: rotation)
+        t = t.scaledBy(x: scale, y: scale)
+        t = t.translatedBy(x: trackCenter.x, y: trackCenter.y)
+        return t
+    }
+
+    func point(for loc: LocationPoint, transform: CGAffineTransform, trackBounds: CGRect, size: CGSize) -> CGPoint {
+        let transformed = CGPoint(x: loc.x, y: loc.y).applying(transform)
+        let nx = (transformed.x - trackBounds.minX) / trackBounds.width
+        let ny = 1 - (transformed.y - trackBounds.minY) / trackBounds.height
+        return CGPoint(x: nx * size.width, y: ny * size.height)
+    }
+
     var body: some View {
         GeometryReader { geo in
-            let points = parseCoordinates()
-            
+            let (points, bounds) = parseTrack()
+            let transform = locationTransform(trackBounds: bounds)
+
             if points.isEmpty {
                 Text("No coordinates available").foregroundColor(.red)
             } else {
-                Path { path in
-                    let first = points[0]
-                    path.move(to: CGPoint(x: first.x * geo.size.width, y: first.y * geo.size.height))
-                    for point in points.dropFirst() {
-                        path.addLine(to: CGPoint(x: point.x * geo.size.width, y: point.y * geo.size.height))
+                ZStack {
+                    Path { path in
+                        let first = points[0]
+                        path.move(to: CGPoint(x: first.x * geo.size.width, y: first.y * geo.size.height))
+                        for point in points.dropFirst() {
+                            path.addLine(to: CGPoint(x: point.x * geo.size.width, y: point.y * geo.size.height))
+                        }
+                        path.closeSubpath()
                     }
-                    path.closeSubpath()
+                    .stroke(Color.blue, lineWidth: 2)
+
+                    if let transform = transform {
+                        ForEach(drivers) { driver in
+                            if let loc = driverPositions[driver.driver_number] {
+                                let p = point(for: loc, transform: transform, trackBounds: bounds, size: geo.size)
+                                Circle()
+                                    .fill(Color.red)
+                                    .frame(width: 8, height: 8)
+                                    .position(p)
+                                Text(driver.initials)
+                                    .font(.caption2)
+                                    .position(x: p.x, y: p.y - 10)
+                            }
+                        }
+                    }
                 }
-                .stroke(Color.blue, lineWidth: 2)
                 .background(Color.gray.opacity(0.1))
                 .cornerRadius(8)
             }

--- a/F1App/F1App/CircuitView.swift
+++ b/F1App/F1App/CircuitView.swift
@@ -9,24 +9,26 @@ import SwiftUI
 
 struct CircuitView: View {
     let coordinatesJSON: String?
-    let drivers: [DriverInfo]
-    let driverPositions: [Int: LocationPoint]
+    @ObservedObject var viewModel: HistoricalRaceViewModel
 
-    init(coordinatesJSON: String?, drivers: [DriverInfo] = [], driverPositions: [Int: LocationPoint] = [:]) {
+    init(coordinatesJSON: String?, viewModel: HistoricalRaceViewModel) {
         self.coordinatesJSON = coordinatesJSON
-        self.drivers = drivers
-        self.driverPositions = driverPositions
+        self.viewModel = viewModel
     }
 
-    // Parse track coordinates and compute bounds
-    func parseTrack() -> ([CGPoint], CGRect) {
+    // Determine track points either from view model or by parsing JSON
+    func trackPoints() -> [CGPoint] {
+        if !viewModel.trackPoints.isEmpty {
+            return viewModel.trackPoints
+        }
+
         guard
             let jsonString = coordinatesJSON,
             let data = jsonString.data(using: .utf8),
             let arr = try? JSONSerialization.jsonObject(with: data) as? [[Double]],
             !arr.isEmpty
         else {
-            return ([], .zero)
+            return []
         }
 
         let xs = arr.map { $0[0] }
@@ -35,61 +37,17 @@ struct CircuitView: View {
         let maxX = xs.max() ?? 1
         let minY = ys.min() ?? 0
         let maxY = ys.max() ?? 1
-        let bounds = CGRect(x: minX, y: minY, width: maxX - minX, height: maxY - minY)
 
-        let points = arr.map { point in
+        return arr.map { point in
             let x = (point[0] - minX) / (maxX - minX)
             let y = 1 - (point[1] - minY) / (maxY - minY)
             return CGPoint(x: x, y: y)
         }
-
-        return (points, bounds)
-    }
-
-    func locationTransform(trackBounds: CGRect) -> CGAffineTransform? {
-        let locs = Array(driverPositions.values)
-        guard !locs.isEmpty,
-              trackBounds.width > 0, trackBounds.height > 0 else { return nil }
-
-        let xs = locs.map { $0.x }
-        let ys = locs.map { $0.y }
-        guard let minX = xs.min(), let maxX = xs.max(),
-              let minY = ys.min(), let maxY = ys.max(),
-              maxX - minX > 0, maxY - minY > 0 else { return nil }
-
-        let locBounds = CGRect(x: minX, y: minY, width: maxX - minX, height: maxY - minY)
-        let trackCenter = CGPoint(x: trackBounds.midX, y: trackBounds.midY)
-        let locCenter = CGPoint(x: locBounds.midX, y: locBounds.midY)
-        let trackVector = CGPoint(x: trackBounds.maxX - trackBounds.minX,
-                                  y: trackBounds.maxY - trackBounds.minY)
-        let locVector = CGPoint(x: locBounds.maxX - locBounds.minX,
-                                y: locBounds.maxY - locBounds.minY)
-        let trackAngle = atan2(trackVector.y, trackVector.x)
-        let locAngle = atan2(locVector.y, locVector.x)
-        let rotation = trackAngle - locAngle
-        let scaleX = trackBounds.width / locBounds.width
-        let scaleY = trackBounds.height / locBounds.height
-        let scale = (scaleX + scaleY) / 2
-
-        var t = CGAffineTransform.identity
-        t = t.translatedBy(x: -locCenter.x, y: -locCenter.y)
-        t = t.rotated(by: rotation)
-        t = t.scaledBy(x: scale, y: scale)
-        t = t.translatedBy(x: trackCenter.x, y: trackCenter.y)
-        return t
-    }
-
-    func point(for loc: LocationPoint, transform: CGAffineTransform, trackBounds: CGRect, size: CGSize) -> CGPoint {
-        let transformed = CGPoint(x: loc.x, y: loc.y).applying(transform)
-        let nx = (transformed.x - trackBounds.minX) / trackBounds.width
-        let ny = 1 - (transformed.y - trackBounds.minY) / trackBounds.height
-        return CGPoint(x: nx * size.width, y: ny * size.height)
     }
 
     var body: some View {
         GeometryReader { geo in
-            let (points, bounds) = parseTrack()
-            let transform = locationTransform(trackBounds: bounds)
+            let points = trackPoints()
 
             if points.isEmpty {
                 Text("No coordinates available").foregroundColor(.red)
@@ -105,18 +63,16 @@ struct CircuitView: View {
                     }
                     .stroke(Color.blue, lineWidth: 2)
 
-                    if let transform = transform {
-                        ForEach(drivers) { driver in
-                            if let loc = driverPositions[driver.driver_number] {
-                                let p = point(for: loc, transform: transform, trackBounds: bounds, size: geo.size)
-                                Circle()
-                                    .fill(Color.red)
-                                    .frame(width: 8, height: 8)
-                                    .position(p)
-                                Text(driver.initials)
-                                    .font(.caption2)
-                                    .position(x: p.x, y: p.y - 10)
-                            }
+                    ForEach(viewModel.drivers) { driver in
+                        if let loc = viewModel.currentPosition[driver.driver_number] {
+                            let p = viewModel.point(for: loc, in: geo.size)
+                            Circle()
+                                .fill(Color.red)
+                                .frame(width: 8, height: 8)
+                                .position(p)
+                            Text(driver.initials)
+                                .font(.caption2)
+                                .position(x: p.x, y: p.y - 10)
                         }
                     }
                 }

--- a/F1App/F1App/CircuitView.swift
+++ b/F1App/F1App/CircuitView.swift
@@ -8,51 +8,76 @@
 import SwiftUI
 
 struct CircuitView: View {
+    let coordinatesJSON: String?
     @ObservedObject var viewModel: HistoricalRaceViewModel
 
     init(coordinatesJSON: String?, viewModel: HistoricalRaceViewModel) {
+        self.coordinatesJSON = coordinatesJSON
         self.viewModel = viewModel
-        viewModel.ensureTrack(from: coordinatesJSON)
+    }
+
+    // Determine track points either from view model or by parsing JSON
+    func trackPoints() -> [CGPoint] {
+        if !viewModel.trackPoints.isEmpty {
+            return viewModel.trackPoints
+        }
+
+        guard
+            let jsonString = coordinatesJSON,
+            let data = jsonString.data(using: .utf8),
+            let arr = try? JSONSerialization.jsonObject(with: data) as? [[Double]],
+            !arr.isEmpty
+        else {
+            return []
+        }
+
+        let xs = arr.map { $0[0] }
+        let ys = arr.map { $0[1] }
+        let minX = xs.min() ?? 0
+        let maxX = xs.max() ?? 1
+        let minY = ys.min() ?? 0
+        let maxY = ys.max() ?? 1
+
+        return arr.map { point in
+            let x = (point[0] - minX) / (maxX - minX)
+            let y = 1 - (point[1] - minY) / (maxY - minY)
+            return CGPoint(x: x, y: y)
+        }
     }
 
     var body: some View {
-        VStack {
-            GeometryReader { geo in
-                let points = viewModel.trackPoints
+        GeometryReader { geo in
+            let points = trackPoints()
 
-                if points.isEmpty {
-                    Text("No coordinates available").foregroundColor(.red)
-                } else {
-                    ZStack {
-                        Path { path in
-                            let first = points[0]
-                            path.move(to: CGPoint(x: first.x * geo.size.width, y: first.y * geo.size.height))
-                            for point in points.dropFirst() {
-                                path.addLine(to: CGPoint(x: point.x * geo.size.width, y: point.y * geo.size.height))
-                            }
-                            path.closeSubpath()
+            if points.isEmpty {
+                Text("No coordinates available").foregroundColor(.red)
+            } else {
+                ZStack {
+                    Path { path in
+                        let first = points[0]
+                        path.move(to: CGPoint(x: first.x * geo.size.width, y: first.y * geo.size.height))
+                        for point in points.dropFirst() {
+                            path.addLine(to: CGPoint(x: point.x * geo.size.width, y: point.y * geo.size.height))
                         }
-                        .stroke(Color.blue, lineWidth: 2)
+                        path.closeSubpath()
+                    }
+                    .stroke(Color.blue, lineWidth: 2)
 
-                        ForEach(viewModel.drivers) { driver in
-                            if let loc = viewModel.currentPosition[driver.driver_number] {
-                                let p = viewModel.point(for: loc, in: geo.size)
-                                Circle()
-                                    .fill(Color.red)
-                                    .frame(width: 8, height: 8)
-                                    .position(p)
-                                Text(driver.initials)
-                                    .font(.caption2)
-                                    .position(x: p.x, y: p.y - 10)
-                            }
+                    ForEach(viewModel.drivers) { driver in
+                        if let loc = viewModel.currentPosition[driver.driver_number] {
+                            let p = viewModel.point(for: loc, in: geo.size)
+                            Circle()
+                                .fill(Color.red)
+                                .frame(width: 8, height: 8)
+                                .position(p)
+                            Text(driver.initials)
+                                .font(.caption2)
+                                .position(x: p.x, y: p.y - 10)
                         }
                     }
-                    .background(Color.gray.opacity(0.1))
-                    .cornerRadius(8)
                 }
-            }
-            if let error = viewModel.errorMessage {
-                Text(error).foregroundColor(.red)
+                .background(Color.gray.opacity(0.1))
+                .cornerRadius(8)
             }
         }
     }

--- a/F1App/F1App/CircuitView.swift
+++ b/F1App/F1App/CircuitView.swift
@@ -8,76 +8,51 @@
 import SwiftUI
 
 struct CircuitView: View {
-    let coordinatesJSON: String?
     @ObservedObject var viewModel: HistoricalRaceViewModel
 
     init(coordinatesJSON: String?, viewModel: HistoricalRaceViewModel) {
-        self.coordinatesJSON = coordinatesJSON
         self.viewModel = viewModel
-    }
-
-    // Determine track points either from view model or by parsing JSON
-    func trackPoints() -> [CGPoint] {
-        if !viewModel.trackPoints.isEmpty {
-            return viewModel.trackPoints
-        }
-
-        guard
-            let jsonString = coordinatesJSON,
-            let data = jsonString.data(using: .utf8),
-            let arr = try? JSONSerialization.jsonObject(with: data) as? [[Double]],
-            !arr.isEmpty
-        else {
-            return []
-        }
-
-        let xs = arr.map { $0[0] }
-        let ys = arr.map { $0[1] }
-        let minX = xs.min() ?? 0
-        let maxX = xs.max() ?? 1
-        let minY = ys.min() ?? 0
-        let maxY = ys.max() ?? 1
-
-        return arr.map { point in
-            let x = (point[0] - minX) / (maxX - minX)
-            let y = 1 - (point[1] - minY) / (maxY - minY)
-            return CGPoint(x: x, y: y)
-        }
+        viewModel.ensureTrack(from: coordinatesJSON)
     }
 
     var body: some View {
-        GeometryReader { geo in
-            let points = trackPoints()
+        VStack {
+            GeometryReader { geo in
+                let points = viewModel.trackPoints
 
-            if points.isEmpty {
-                Text("No coordinates available").foregroundColor(.red)
-            } else {
-                ZStack {
-                    Path { path in
-                        let first = points[0]
-                        path.move(to: CGPoint(x: first.x * geo.size.width, y: first.y * geo.size.height))
-                        for point in points.dropFirst() {
-                            path.addLine(to: CGPoint(x: point.x * geo.size.width, y: point.y * geo.size.height))
+                if points.isEmpty {
+                    Text("No coordinates available").foregroundColor(.red)
+                } else {
+                    ZStack {
+                        Path { path in
+                            let first = points[0]
+                            path.move(to: CGPoint(x: first.x * geo.size.width, y: first.y * geo.size.height))
+                            for point in points.dropFirst() {
+                                path.addLine(to: CGPoint(x: point.x * geo.size.width, y: point.y * geo.size.height))
+                            }
+                            path.closeSubpath()
                         }
-                        path.closeSubpath()
-                    }
-                    .stroke(Color.blue, lineWidth: 2)
+                        .stroke(Color.blue, lineWidth: 2)
 
-                    ForEach(viewModel.drivers) { driver in
-                        if let loc = viewModel.currentPosition[driver.driver_number] {
-                            let p = viewModel.point(for: loc, in: geo.size)
-                            Circle()
-                                .fill(Color.red)
-                                .frame(width: 8, height: 8)
-                                .position(p)
-                            Text(driver.initials)
-                                .font(.caption2)
-                                .position(x: p.x, y: p.y - 10)
+                        ForEach(viewModel.drivers) { driver in
+                            if let loc = viewModel.currentPosition[driver.driver_number] {
+                                let p = viewModel.point(for: loc, in: geo.size)
+                                Circle()
+                                    .fill(Color.red)
+                                    .frame(width: 8, height: 8)
+                                    .position(p)
+                                Text(driver.initials)
+                                    .font(.caption2)
+                                    .position(x: p.x, y: p.y - 10)
+                            }
                         }
                     }
+                    .background(Color.gray.opacity(0.1))
+                    .cornerRadius(8)
                 }
-                .background(Color.gray.opacity(0.1))
-                .cornerRadius(8)
+            }
+            if let error = viewModel.errorMessage {
+                Text(error).foregroundColor(.red)
             }
         }
     }

--- a/F1App/F1App/HistoricalRaceView.swift
+++ b/F1App/F1App/HistoricalRaceView.swift
@@ -24,6 +24,15 @@ struct HistoricalRaceView: View {
 
             if !viewModel.trackPoints.isEmpty {
                 GeometryReader { geo in
+                    let bounds = CGRect(origin: .zero, size: geo.size)
+                    let outOfBounds = viewModel.drivers.contains { driver in
+                        if let loc = viewModel.currentPosition[driver.driver_number] {
+                            let p = viewModel.point(for: loc, in: geo.size)
+                            return !bounds.contains(p)
+                        }
+                        return false
+                    }
+
                     ZStack {
                         Path { path in
                             guard let first = viewModel.trackPoints.first else { return }
@@ -41,14 +50,21 @@ struct HistoricalRaceView: View {
                             ForEach(viewModel.drivers) { driver in
                                 if let loc = viewModel.currentPosition[driver.driver_number] {
                                     let point = viewModel.point(for: loc, in: geo.size)
-                                    Circle()
-                                        .fill(Color.red)
-                                        .frame(width: 8, height: 8)
-                                        .position(point)
-                                    Text(driver.initials)
-                                        .font(.caption2)
-                                        .position(x: point.x, y: point.y - 10)
+                                    if bounds.contains(point) {
+                                        Circle()
+                                            .fill(Color.red)
+                                            .frame(width: 8, height: 8)
+                                            .position(point)
+                                        Text(driver.initials)
+                                            .font(.caption2)
+                                            .position(x: point.x, y: point.y - 10)
+                                    }
                                 }
+                            }
+                            if outOfBounds {
+                                Text("Puncte în afara circuitului")
+                                    .foregroundColor(.red)
+                                    .position(x: geo.size.width / 2, y: 20)
                             }
                         }
                     }

--- a/F1App/F1App/HistoricalRaceView.swift
+++ b/F1App/F1App/HistoricalRaceView.swift
@@ -72,6 +72,25 @@ struct HistoricalRaceView: View {
                     viewModel.isRunning ? viewModel.pause() : viewModel.start()
                 }
                 .padding(.bottom)
+
+                List(viewModel.drivers) { driver in
+                    if let loc = viewModel.currentPosition[driver.driver_number] {
+                        HStack {
+                            Text(driver.full_name)
+                            Spacer()
+                            Text(String(format: "(%.2f, %.2f)", loc.x, loc.y))
+                                .font(.caption)
+                        }
+                    } else {
+                        HStack {
+                            Text(driver.full_name)
+                            Spacer()
+                            Text("N/A")
+                                .font(.caption)
+                        }
+                    }
+                }
+                .frame(maxHeight: 200)
             }
             Spacer()
         }

--- a/F1App/F1App/HistoricalRaceView.swift
+++ b/F1App/F1App/HistoricalRaceView.swift
@@ -56,6 +56,18 @@ struct HistoricalRaceView: View {
                 .cornerRadius(8)
                 .padding()
 
+                if viewModel.maxSteps > 1 {
+                    Slider(
+                        value: Binding(
+                            get: { Double(viewModel.stepIndex) },
+                            set: { viewModel.stepIndex = Int($0); viewModel.updatePositions() }
+                        ),
+                        in: 0...Double(viewModel.maxSteps - 1),
+                        step: 1
+                    )
+                    .padding(.horizontal)
+                }
+
                 Button(viewModel.isRunning ? "Pauză" : "Start") {
                     viewModel.isRunning ? viewModel.pause() : viewModel.start()
                 }

--- a/F1App/F1App/HistoricalRaceView.swift
+++ b/F1App/F1App/HistoricalRaceView.swift
@@ -1,0 +1,67 @@
+import SwiftUI
+
+struct HistoricalRaceView: View {
+    let race: Race
+    @StateObject private var viewModel = HistoricalRaceViewModel()
+
+    var body: some View {
+        VStack {
+            HStack {
+                TextField("Anul", text: $viewModel.year)
+                    .keyboardType(.numberPad)
+                    .textFieldStyle(RoundedBorderTextFieldStyle())
+                Button("Caută") {
+                    viewModel.load(for: race)
+                }
+            }
+            .padding()
+
+            if let error = viewModel.errorMessage {
+                Text(error)
+                    .foregroundColor(.red)
+                    .padding(.bottom)
+            }
+
+            if !viewModel.trackPoints.isEmpty && !viewModel.currentPosition.isEmpty {
+                GeometryReader { geo in
+                    ZStack {
+                        Path { path in
+                            guard let first = viewModel.trackPoints.first else { return }
+                            path.move(to: CGPoint(x: first.x * geo.size.width,
+                                                  y: first.y * geo.size.height))
+                            for p in viewModel.trackPoints.dropFirst() {
+                                path.addLine(to: CGPoint(x: p.x * geo.size.width,
+                                                         y: p.y * geo.size.height))
+                            }
+                            path.closeSubpath()
+                        }
+                        .stroke(Color.blue, lineWidth: 2)
+
+                        ForEach(viewModel.drivers) { driver in
+                            if let loc = viewModel.currentPosition[driver.driver_number] {
+                                let point = viewModel.point(for: loc, in: geo.size)
+                                Circle()
+                                    .fill(Color.red)
+                                    .frame(width: 8, height: 8)
+                                    .position(point)
+                                Text(driver.initials)
+                                    .font(.caption2)
+                                    .position(x: point.x, y: point.y - 10)
+                            }
+                        }
+                    }
+                }
+                .frame(height: 300)
+                .background(Color.gray.opacity(0.1))
+                .cornerRadius(8)
+                .padding()
+
+                Button(viewModel.isRunning ? "Pauză" : "Start") {
+                    viewModel.isRunning ? viewModel.pause() : viewModel.start()
+                }
+                .padding(.bottom)
+            }
+            Spacer()
+        }
+    }
+}

--- a/F1App/F1App/HistoricalRaceView.swift
+++ b/F1App/F1App/HistoricalRaceView.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 struct HistoricalRaceView: View {
     let race: Race
-    @StateObject private var viewModel = HistoricalRaceViewModel()
+    @ObservedObject var viewModel: HistoricalRaceViewModel
 
     var body: some View {
         VStack {
@@ -22,7 +22,7 @@ struct HistoricalRaceView: View {
                     .padding(.bottom)
             }
 
-            if !viewModel.trackPoints.isEmpty && !viewModel.currentPosition.isEmpty {
+            if !viewModel.trackPoints.isEmpty {
                 GeometryReader { geo in
                     ZStack {
                         Path { path in
@@ -37,16 +37,18 @@ struct HistoricalRaceView: View {
                         }
                         .stroke(Color.blue, lineWidth: 2)
 
-                        ForEach(viewModel.drivers) { driver in
-                            if let loc = viewModel.currentPosition[driver.driver_number] {
-                                let point = viewModel.point(for: loc, in: geo.size)
-                                Circle()
-                                    .fill(Color.red)
-                                    .frame(width: 8, height: 8)
-                                    .position(point)
-                                Text(driver.initials)
-                                    .font(.caption2)
-                                    .position(x: point.x, y: point.y - 10)
+                        if !viewModel.currentPosition.isEmpty {
+                            ForEach(viewModel.drivers) { driver in
+                                if let loc = viewModel.currentPosition[driver.driver_number] {
+                                    let point = viewModel.point(for: loc, in: geo.size)
+                                    Circle()
+                                        .fill(Color.red)
+                                        .frame(width: 8, height: 8)
+                                        .position(point)
+                                    Text(driver.initials)
+                                        .font(.caption2)
+                                        .position(x: point.x, y: point.y - 10)
+                                }
                             }
                         }
                     }
@@ -55,6 +57,12 @@ struct HistoricalRaceView: View {
                 .background(Color.gray.opacity(0.1))
                 .cornerRadius(8)
                 .padding()
+
+                if viewModel.currentPosition.isEmpty {
+                    Text("Date de locație indisponibile")
+                        .foregroundColor(.red)
+                        .padding(.bottom)
+                }
 
                 if viewModel.maxSteps > 1 {
                     Slider(

--- a/F1App/F1App/HistoricalRaceViewModel.swift
+++ b/F1App/F1App/HistoricalRaceViewModel.swift
@@ -7,7 +7,7 @@ struct Meeting: Decodable {
     let date_start: String
 }
 
-struct DriverInfo: Identifiable, Decodable {
+struct DriverInfo: Identifiable, Decodable, Hashable {
     let driver_number: Int
     let full_name: String
 
@@ -131,8 +131,9 @@ class HistoricalRaceViewModel: ObservableObject {
         URLSession.shared.dataTask(with: url) { data, _, _ in
             guard let data = data,
                   let drivers = try? JSONDecoder().decode([DriverInfo].self, from: data) else { return }
+            let uniqueDrivers = Array(Set(drivers))
             DispatchQueue.main.async {
-                self.drivers = drivers
+                self.drivers = uniqueDrivers
                 self.fetchLocations(sessionKey: sessionKey)
             }
         }.resume()

--- a/F1App/F1App/HistoricalRaceViewModel.swift
+++ b/F1App/F1App/HistoricalRaceViewModel.swift
@@ -194,7 +194,8 @@ class HistoricalRaceViewModel: ObservableObject {
                         }
                     }
                     self.errorMessage = self.positions.isEmpty ? "Date de locație indisponibile" : nil
-                    if !self.hasInitialLocations, !self.positions.isEmpty {
+                    let totalLocations = self.positions.values.reduce(0) { $0 + $1.count }
+                    if !self.hasInitialLocations, totalLocations >= 2 {
                         self.calculateLocationBounds()
                         self.updatePositions()
                         self.hasInitialLocations = true
@@ -241,7 +242,7 @@ class HistoricalRaceViewModel: ObservableObject {
         locationTransform = t
     }
 
-    func point(for loc: LocationPoint, in size: CGSize) -> CGPoint {
+    public func point(for loc: LocationPoint, in size: CGSize) -> CGPoint {
         let transformed = CGPoint(x: loc.x, y: loc.y).applying(locationTransform)
         let nx = (transformed.x - trackBounds.minX) / trackBounds.width
         let ny = 1 - (transformed.y - trackBounds.minY) / trackBounds.height

--- a/F1App/F1App/HistoricalRaceViewModel.swift
+++ b/F1App/F1App/HistoricalRaceViewModel.swift
@@ -180,7 +180,17 @@ class HistoricalRaceViewModel: ObservableObject {
         URLSession.shared.dataTask(with: url) { data, _, error in
             if let data = data, error == nil,
                let locs = try? JSONDecoder().decode([LocationPoint].self, from: data) {
-                let grouped = Dictionary(grouping: locs, by: { $0.driver_number })
+                // Scale down coordinates by a factor of 10 to better fit the track
+                let scaledLocs = locs.map { original in
+                    LocationPoint(
+                        driver_number: original.driver_number,
+                        date: original.date,
+                        x: original.x / 10.0,
+                        y: original.y / 10.0
+                    )
+                }
+
+                let grouped = Dictionary(grouping: scaledLocs, by: { $0.driver_number })
 
                 DispatchQueue.main.async {
                     var exceededBounds = false

--- a/F1App/F1App/HistoricalRaceViewModel.swift
+++ b/F1App/F1App/HistoricalRaceViewModel.swift
@@ -1,0 +1,157 @@
+import Foundation
+import SwiftUI
+import CoreLocation
+
+struct Meeting: Decodable {
+    let meeting_key: Int
+    let date_start: String
+}
+
+struct DriverInfo: Identifiable, Decodable {
+    let driver_number: Int
+    let full_name: String
+
+    var id: Int { driver_number }
+    var initials: String {
+        let parts = full_name.split(separator: " ")
+        return parts.compactMap { $0.first }.map { String($0) }.joined()
+    }
+}
+
+struct LocationPoint: Decodable {
+    let driver_number: Int
+    let date: String
+    let x: Double
+    let y: Double
+}
+
+class HistoricalRaceViewModel: ObservableObject {
+    @Published var year: String = ""
+    @Published var errorMessage: String?
+    @Published var meeting: Meeting?
+    @Published var drivers: [DriverInfo] = []
+    @Published var positions: [Int: [LocationPoint]] = [:]
+    @Published var currentPosition: [Int: LocationPoint] = [:]
+    @Published var isRunning = false
+    @Published var trackPoints: [CGPoint] = []
+
+    private var timer: Timer?
+    private var stepIndex = 0
+    private var minX: Double = 0
+    private var maxX: Double = 1
+    private var minY: Double = 0
+    private var maxY: Double = 1
+
+    func load(for race: Race) {
+        parseTrack(race.coordinates)
+        guard let circuitId = race.circuit_id, let yearInt = Int(year) else {
+            errorMessage = "Selectează un an valid"
+            return
+        }
+        fetchMeeting(circuitId: circuitId, year: yearInt)
+    }
+
+    private func parseTrack(_ json: String?) {
+        guard
+            let json = json,
+            let data = json.data(using: .utf8),
+            let arr = try? JSONSerialization.jsonObject(with: data) as? [[Double]]
+        else { return }
+
+        let xs = arr.map { $0[0] }
+        let ys = arr.map { $0[1] }
+        minX = xs.min() ?? 0
+        maxX = xs.max() ?? 1
+        minY = ys.min() ?? 0
+        maxY = ys.max() ?? 1
+        trackPoints = arr.map { point in
+            let x = (point[0] - minX) / (maxX - minX)
+            let y = 1 - (point[1] - minY) / (maxY - minY)
+            return CGPoint(x: x, y: y)
+        }
+    }
+
+    private func fetchMeeting(circuitId: String, year: Int) {
+        guard let url = URL(string: "https://api.openf1.org/v1/meetings?circuit_key=\(circuitId)") else { return }
+        URLSession.shared.dataTask(with: url) { data, _, _ in
+            guard let data = data,
+                  let meetings = try? JSONDecoder().decode([Meeting].self, from: data),
+                  let meeting = meetings.first(where: { self.year(from: $0.date_start) == year }) else {
+                DispatchQueue.main.async {
+                    self.errorMessage = "Nu a fost cursa pe acel circuit in acel an"
+                }
+                return
+            }
+            DispatchQueue.main.async {
+                self.meeting = meeting
+                self.errorMessage = nil
+                self.fetchDrivers(meetingKey: meeting.meeting_key)
+            }
+        }.resume()
+    }
+
+    private func fetchDrivers(meetingKey: Int) {
+        guard let url = URL(string: "https://api.openf1.org/v1/drivers?meeting_key=\(meetingKey)") else { return }
+        URLSession.shared.dataTask(with: url) { data, _, _ in
+            guard let data = data,
+                  let drivers = try? JSONDecoder().decode([DriverInfo].self, from: data) else { return }
+            DispatchQueue.main.async {
+                self.drivers = drivers
+                self.fetchLocations()
+            }
+        }.resume()
+    }
+
+    private func fetchLocations() {
+        guard let meeting = meeting else { return }
+        let formatter = ISO8601DateFormatter()
+        guard let start = formatter.date(from: meeting.date_start) else { return }
+        let end = start.addingTimeInterval(3 * 60 * 60)
+        let startStr = formatter.string(from: start)
+        let endStr = formatter.string(from: end)
+
+        for driver in drivers {
+            let urlString = "https://api.openf1.org/v1/location?meeting_key=\(meeting.meeting_key)&driver_number=\(driver.driver_number)&date>=\(startStr)&date<=\(endStr)"
+            guard let encoded = urlString.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed),
+                  let url = URL(string: encoded) else { continue }
+            URLSession.shared.dataTask(with: url) { data, _, _ in
+                guard let data = data,
+                      let locs = try? JSONDecoder().decode([LocationPoint].self, from: data),
+                      !locs.isEmpty else { return }
+                DispatchQueue.main.async {
+                    self.positions[driver.driver_number] = locs
+                    self.currentPosition[driver.driver_number] = locs.first
+                }
+            }.resume()
+        }
+    }
+
+    func point(for loc: LocationPoint, in size: CGSize) -> CGPoint {
+        let nx = (loc.x - minX) / (maxX - minX)
+        let ny = 1 - (loc.y - minY) / (maxY - minY)
+        return CGPoint(x: nx * size.width, y: ny * size.height)
+    }
+
+    func start() {
+        guard !isRunning else { pause(); return }
+        isRunning = true
+        timer = Timer.scheduledTimer(withTimeInterval: 1, repeats: true) { _ in
+            self.stepIndex += 1
+            for driver in self.drivers {
+                if let arr = self.positions[driver.driver_number], self.stepIndex < arr.count {
+                    self.currentPosition[driver.driver_number] = arr[self.stepIndex]
+                }
+            }
+        }
+    }
+
+    func pause() {
+        isRunning = false
+        timer?.invalidate()
+        timer = nil
+    }
+
+    private func year(from iso: String) -> Int {
+        return Int(iso.prefix(4)) ?? 0
+    }
+}

--- a/F1App/F1App/HistoricalRaceViewModel.swift
+++ b/F1App/F1App/HistoricalRaceViewModel.swift
@@ -28,6 +28,8 @@ struct LocationPoint: Decodable {
 struct SessionInfo: Decodable {
     let session_key: Int
     let session_name: String
+    let date_start: String?
+    let date_end: String?
 }
 
 class HistoricalRaceViewModel: ObservableObject {
@@ -40,6 +42,8 @@ class HistoricalRaceViewModel: ObservableObject {
     @Published var isRunning = false
     @Published var trackPoints: [CGPoint] = []
     @Published var sessionKey: Int?
+    @Published var sessionStart: String?
+    @Published var sessionEnd: String?
 
     private var timer: Timer?
     private var stepIndex = 0
@@ -109,6 +113,8 @@ class HistoricalRaceViewModel: ObservableObject {
             }
             DispatchQueue.main.async {
                 self.sessionKey = session.session_key
+                self.sessionStart = session.date_start
+                self.sessionEnd = session.date_end
                 self.errorMessage = nil
                 self.fetchDrivers(meetingKey: meetingKey, sessionKey: session.session_key)
             }
@@ -128,10 +134,17 @@ class HistoricalRaceViewModel: ObservableObject {
     }
 
     private func fetchLocations(sessionKey: Int) {
-        guard let meeting = meeting else { return }
         let formatter = ISO8601DateFormatter()
-        guard let start = formatter.date(from: meeting.date_start) else { return }
-        let end = start.addingTimeInterval(3 * 60 * 60)
+        guard let startString = sessionStart,
+              let start = formatter.date(from: startString) else { return }
+
+        let end: Date
+        if let endString = sessionEnd, let endDate = formatter.date(from: endString) {
+            end = endDate
+        } else {
+            end = start.addingTimeInterval(3 * 60 * 60)
+        }
+
         let startStr = formatter.string(from: start)
         let endStr = formatter.string(from: end)
 

--- a/F1App/F1App/HistoricalRaceViewModel.swift
+++ b/F1App/F1App/HistoricalRaceViewModel.swift
@@ -53,13 +53,6 @@ class HistoricalRaceViewModel: ObservableObject {
     private var isFetchingLocations = false
     private var hasInitialLocations = false
 
-    /// Prepare track geometry if it hasn't been parsed yet.
-    /// - Parameter json: JSON string with track coordinates.
-    func ensureTrack(from json: String?) {
-        guard trackPoints.isEmpty else { return }
-        parseTrack(json)
-    }
-
     func load(for race: Race) {
         pause()
         stepIndex = 0
@@ -73,7 +66,7 @@ class HistoricalRaceViewModel: ObservableObject {
         fetchMeeting(circuitId: circuitId, year: yearInt)
     }
 
-    func parseTrack(_ json: String?) {
+    private func parseTrack(_ json: String?) {
         guard
             let json = json,
             let data = json.data(using: .utf8),
@@ -201,16 +194,12 @@ class HistoricalRaceViewModel: ObservableObject {
                         }
                     }
                     self.errorMessage = self.positions.isEmpty ? "Date de locație indisponibile" : nil
-                    if !self.hasInitialLocations {
-                        let allPoints = self.positions.values.flatMap { $0 }
-                        let uniqueXs = Set(allPoints.map { $0.x })
-                        let uniqueYs = Set(allPoints.map { $0.y })
-                        if uniqueXs.count > 1 && uniqueYs.count > 1 {
-                            self.calculateLocationBounds()
-                            self.updatePositions()
-                            self.hasInitialLocations = true
-                        }
-                    } else {
+                    let totalLocations = self.positions.values.reduce(0) { $0 + $1.count }
+                    if !self.hasInitialLocations, totalLocations >= 2 {
+                        self.calculateLocationBounds()
+                        self.updatePositions()
+                        self.hasInitialLocations = true
+                    } else if self.hasInitialLocations {
                         self.updatePositions()
                     }
                 }
@@ -232,10 +221,7 @@ class HistoricalRaceViewModel: ObservableObject {
         let maxX = xs.max() ?? 1
         let minY = ys.min() ?? 0
         let maxY = ys.max() ?? 1
-        let width = maxX - minX
-        let height = maxY - minY
-        guard width > 0 && height > 0 else { return }
-        locationBounds = CGRect(x: minX, y: minY, width: width, height: height)
+        locationBounds = CGRect(x: minX, y: minY, width: maxX - minX, height: maxY - minY)
 
         let trackCenter = CGPoint(x: trackBounds.midX, y: trackBounds.midY)
         let locCenter = CGPoint(x: locationBounds.midX, y: locationBounds.midY)
@@ -260,11 +246,7 @@ class HistoricalRaceViewModel: ObservableObject {
         let transformed = CGPoint(x: loc.x, y: loc.y).applying(locationTransform)
         let nx = (transformed.x - trackBounds.minX) / trackBounds.width
         let ny = 1 - (transformed.y - trackBounds.minY) / trackBounds.height
-        let point = CGPoint(x: nx * size.width, y: ny * size.height)
-        if point.x < 0 || point.x > size.width || point.y < 0 || point.y > size.height {
-            errorMessage = "Puncte în afara Canvasului"
-        }
-        return point
+        return CGPoint(x: nx * size.width, y: ny * size.height)
     }
 
     func start() {
@@ -287,16 +269,11 @@ class HistoricalRaceViewModel: ObservableObject {
         timer = nil
     }
 
-    deinit {
-        timer?.invalidate()
-    }
-
     var maxSteps: Int {
         positions.values.map { $0.count }.max() ?? 0
     }
 
     func updatePositions() {
-        errorMessage = nil
         for driver in drivers {
             if let arr = positions[driver.driver_number], stepIndex < arr.count {
                 currentPosition[driver.driver_number] = arr[stepIndex]

--- a/F1App/F1App/RaceDetailView.swift
+++ b/F1App/F1App/RaceDetailView.swift
@@ -10,9 +10,10 @@ import MapKit
 
 struct RaceDetailView: View {
     let race: Race
-    
+
     @State private var selectedTab = 0
-    
+    @StateObject private var viewModel = HistoricalRaceViewModel()
+
     var body: some View {
         VStack {
             Picker("Select Section", selection: $selectedTab) {
@@ -26,13 +27,15 @@ struct RaceDetailView: View {
             Spacer()
             
             if selectedTab == 0 {
-                CircuitView(coordinatesJSON: race.coordinates)
+                CircuitView(coordinatesJSON: race.coordinates,
+                            drivers: viewModel.drivers,
+                            driverPositions: viewModel.currentPosition)
                     .frame(height: UIScreen.main.bounds.height / 2)
                     .padding()
             } else if selectedTab == 1 {
                 Text("Section 2 content").font(.title)
             } else {
-                HistoricalRaceView(race: race)
+                HistoricalRaceView(race: race, viewModel: viewModel)
             }
             
             Spacer()

--- a/F1App/F1App/RaceDetailView.swift
+++ b/F1App/F1App/RaceDetailView.swift
@@ -18,7 +18,7 @@ struct RaceDetailView: View {
             Picker("Select Section", selection: $selectedTab) {
                 Text("Circuit").tag(0)
                 Text("Section 2").tag(1)
-                Text("Section 3").tag(2)
+                Text("Curse istorice").tag(2)
             }
             .pickerStyle(SegmentedPickerStyle())
             .padding()
@@ -32,7 +32,7 @@ struct RaceDetailView: View {
             } else if selectedTab == 1 {
                 Text("Section 2 content").font(.title)
             } else {
-                Text("Section 3 content").font(.title)
+                HistoricalRaceView(race: race)
             }
             
             Spacer()

--- a/F1App/F1App/RaceDetailView.swift
+++ b/F1App/F1App/RaceDetailView.swift
@@ -27,9 +27,7 @@ struct RaceDetailView: View {
             Spacer()
             
             if selectedTab == 0 {
-                CircuitView(coordinatesJSON: race.coordinates,
-                            drivers: viewModel.drivers,
-                            driverPositions: viewModel.currentPosition)
+                CircuitView(coordinatesJSON: race.coordinates, viewModel: viewModel)
                     .frame(height: UIScreen.main.bounds.height / 2)
                     .padding()
             } else if selectedTab == 1 {


### PR DESCRIPTION
## Summary
- integrate historical race viewer in race details
- add view model to fetch meeting, driver and location data from OpenF1 API
- allow start/pause simulation of driver positions on circuit

## Testing
- `swiftc -typecheck F1App/F1App/HistoricalRaceView.swift` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_689dbc3459d083238338e1dc276087f2