### PR TITLE
Use session times for historical race locations

### DIFF
--- a/F1App/F1App/HistoricalRaceViewModel.swift
+++ b/F1App/F1App/HistoricalRaceViewModel.swift
@@ -28,6 +28,8 @@ struct LocationPoint: Decodable {
 struct SessionInfo: Decodable {
     let session_key: Int
     let session_name: String
+    let date_start: String?
+    let date_end: String?
 }
 
 class HistoricalRaceViewModel: ObservableObject {
@@ -40,6 +42,8 @@ class HistoricalRaceViewModel: ObservableObject {
     @Published var isRunning = false
     @Published var trackPoints: [CGPoint] = []
     @Published var sessionKey: Int?
+    @Published var sessionStart: String?
+    @Published var sessionEnd: String?
 
     private var timer: Timer?
     private var stepIndex = 0
@@ -109,6 +113,8 @@ class HistoricalRaceViewModel: ObservableObject {
             }
             DispatchQueue.main.async {
                 self.sessionKey = session.session_key
+                self.sessionStart = session.date_start
+                self.sessionEnd = session.date_end
                 self.errorMessage = nil
                 self.fetchDrivers(meetingKey: meetingKey, sessionKey: session.session_key)
             }
@@ -128,10 +134,17 @@ class HistoricalRaceViewModel: ObservableObject {
     }
 
     private func fetchLocations(sessionKey: Int) {
-        guard let meeting = meeting else { return }
         let formatter = ISO8601DateFormatter()
-        guard let start = formatter.date(from: meeting.date_start) else { return }
-        let end = start.addingTimeInterval(3 * 60 * 60)
+        guard let startString = sessionStart,
+              let start = formatter.date(from: startString) else { return }
+
+        let end: Date
+        if let endString = sessionEnd, let endDate = formatter.date(from: endString) {
+            end = endDate
+        } else {
+            end = start.addingTimeInterval(3 * 60 * 60)
+        }
+
         let startStr = formatter.string(from: start)
         let endStr = formatter.string(from: end)
 


### PR DESCRIPTION
## Summary
- Decode `date_start` and `date_end` for sessions and persist them in the view model
- Query location data using the session's start/end window instead of the meeting date

## Testing
- `swiftc -typecheck F1App/F1App/HistoricalRaceViewModel.swift` *(fails: no such module 'SwiftUI')*
- `curl -s 'https://api.openf1.org/v1/location?session_key=7953&driver_number=1&date%3E=2023-03-05T15:00:00Z&date%3C=2023-03-05T17:00:00Z' | head -c 1000`


------
https://chatgpt.com/codex/tasks/task_e_689dc72d12c88323bc2de2ffc1954416