### PR TITLE
Improve historical race playback controls and data handling

### DIFF
--- a/F1App/F1App/HistoricalRaceView.swift
+++ b/F1App/F1App/HistoricalRaceView.swift
@@ -56,6 +56,18 @@ struct HistoricalRaceView: View {
                 .cornerRadius(8)
                 .padding()
 
+                if viewModel.maxSteps > 1 {
+                    Slider(
+                        value: Binding(
+                            get: { Double(viewModel.stepIndex) },
+                            set: { viewModel.stepIndex = Int($0); viewModel.updatePositions() }
+                        ),
+                        in: 0...Double(viewModel.maxSteps - 1),
+                        step: 1
+                    )
+                    .padding(.horizontal)
+                }
+
                 Button(viewModel.isRunning ? "Pauză" : "Start") {
                     viewModel.isRunning ? viewModel.pause() : viewModel.start()
                 }


### PR DESCRIPTION
## Summary
- Add timeline slider to HistoricalRaceView for scrubbing through race positions
- Refactor HistoricalRaceViewModel to handle missing location data gracefully and expose playback state
- Reset state on new loads and update positions when slider moves

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_689dce6cd03883238172bd361a47fe36