### PR TITLE
Deduplicate drivers in historical race view

### DIFF
--- a/F1App/F1App/HistoricalRaceViewModel.swift
+++ b/F1App/F1App/HistoricalRaceViewModel.swift
@@ -7,7 +7,7 @@ struct Meeting: Decodable {
     let date_start: String
 }
 
-struct DriverInfo: Identifiable, Decodable {
+struct DriverInfo: Identifiable, Decodable, Hashable {
     let driver_number: Int
     let full_name: String
 
@@ -131,8 +131,9 @@ class HistoricalRaceViewModel: ObservableObject {
         URLSession.shared.dataTask(with: url) { data, _, _ in
             guard let data = data,
                   let drivers = try? JSONDecoder().decode([DriverInfo].self, from: data) else { return }
+            let uniqueDrivers = Array(Set(drivers))
             DispatchQueue.main.async {
-                self.drivers = drivers
+                self.drivers = uniqueDrivers
                 self.fetchLocations(sessionKey: sessionKey)
             }
         }.resume()


### PR DESCRIPTION
## Summary
- Ensure `DriverInfo` is `Hashable` to allow set-based uniqueness checks
- Deduplicate drivers after decoding in `fetchDrivers` and then fetch locations

## Testing
- `swift test` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*

------
https://chatgpt.com/codex/tasks/task_e_689dd37a87948323a16329fd2867cc50