### PR TITLE
Show driver coordinates list in historical race

### DIFF
--- a/F1App/F1App/HistoricalRaceView.swift
+++ b/F1App/F1App/HistoricalRaceView.swift
@@ -72,6 +72,25 @@ struct HistoricalRaceView: View {
                     viewModel.isRunning ? viewModel.pause() : viewModel.start()
                 }
                 .padding(.bottom)
+
+                List(viewModel.drivers) { driver in
+                    if let loc = viewModel.currentPosition[driver.driver_number] {
+                        HStack {
+                            Text(driver.full_name)
+                            Spacer()
+                            Text(String(format: "(%.2f, %.2f)", loc.x, loc.y))
+                                .font(.caption)
+                        }
+                    } else {
+                        HStack {
+                            Text(driver.full_name)
+                            Spacer()
+                            Text("N/A")
+                                .font(.caption)
+                        }
+                    }
+                }
+                .frame(maxHeight: 200)
             }
             Spacer()
         }


### PR DESCRIPTION
## Summary
- Display a list of drivers with their current (x,y) coordinates during historical race playback

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_689dfdb560ec832389238a880b3c2e75