### PR TITLE
Connect CircuitView to HistoricalRaceViewModel for driver markers

### DIFF
--- a/F1App/F1App/CircuitView.swift
+++ b/F1App/F1App/CircuitView.swift
@@ -9,24 +9,26 @@ import SwiftUI
 
 struct CircuitView: View {
     let coordinatesJSON: String?
-    let drivers: [DriverInfo]
-    let driverPositions: [Int: LocationPoint]
+    @ObservedObject var viewModel: HistoricalRaceViewModel
 
-    init(coordinatesJSON: String?, drivers: [DriverInfo] = [], driverPositions: [Int: LocationPoint] = [:]) {
+    init(coordinatesJSON: String?, viewModel: HistoricalRaceViewModel) {
         self.coordinatesJSON = coordinatesJSON
-        self.drivers = drivers
-        self.driverPositions = driverPositions
+        self.viewModel = viewModel
     }
 
-    // Parse track coordinates and compute bounds
-    func parseTrack() -> ([CGPoint], CGRect) {
+    // Determine track points either from view model or by parsing JSON
+    func trackPoints() -> [CGPoint] {
+        if !viewModel.trackPoints.isEmpty {
+            return viewModel.trackPoints
+        }
+
         guard
             let jsonString = coordinatesJSON,
             let data = jsonString.data(using: .utf8),
             let arr = try? JSONSerialization.jsonObject(with: data) as? [[Double]],
             !arr.isEmpty
         else {
-            return ([], .zero)
+            return []
         }
 
         let xs = arr.map { $0[0] }
@@ -35,61 +37,17 @@ struct CircuitView: View {
         let maxX = xs.max() ?? 1
         let minY = ys.min() ?? 0
         let maxY = ys.max() ?? 1
-        let bounds = CGRect(x: minX, y: minY, width: maxX - minX, height: maxY - minY)
 
-        let points = arr.map { point in
+        return arr.map { point in
             let x = (point[0] - minX) / (maxX - minX)
             let y = 1 - (point[1] - minY) / (maxY - minY)
             return CGPoint(x: x, y: y)
         }
-
-        return (points, bounds)
-    }
-
-    func locationTransform(trackBounds: CGRect) -> CGAffineTransform? {
-        let locs = Array(driverPositions.values)
-        guard !locs.isEmpty,
-              trackBounds.width > 0, trackBounds.height > 0 else { return nil }
-
-        let xs = locs.map { $0.x }
-        let ys = locs.map { $0.y }
-        guard let minX = xs.min(), let maxX = xs.max(),
-              let minY = ys.min(), let maxY = ys.max(),
-              maxX - minX > 0, maxY - minY > 0 else { return nil }
-
-        let locBounds = CGRect(x: minX, y: minY, width: maxX - minX, height: maxY - minY)
-        let trackCenter = CGPoint(x: trackBounds.midX, y: trackBounds.midY)
-        let locCenter = CGPoint(x: locBounds.midX, y: locBounds.midY)
-        let trackVector = CGPoint(x: trackBounds.maxX - trackBounds.minX,
-                                  y: trackBounds.maxY - trackBounds.minY)
-        let locVector = CGPoint(x: locBounds.maxX - locBounds.minX,
-                                y: locBounds.maxY - locBounds.minY)
-        let trackAngle = atan2(trackVector.y, trackVector.x)
-        let locAngle = atan2(locVector.y, locVector.x)
-        let rotation = trackAngle - locAngle
-        let scaleX = trackBounds.width / locBounds.width
-        let scaleY = trackBounds.height / locBounds.height
-        let scale = (scaleX + scaleY) / 2
-
-        var t = CGAffineTransform.identity
-        t = t.translatedBy(x: -locCenter.x, y: -locCenter.y)
-        t = t.rotated(by: rotation)
-        t = t.scaledBy(x: scale, y: scale)
-        t = t.translatedBy(x: trackCenter.x, y: trackCenter.y)
-        return t
-    }
-
-    func point(for loc: LocationPoint, transform: CGAffineTransform, trackBounds: CGRect, size: CGSize) -> CGPoint {
-        let transformed = CGPoint(x: loc.x, y: loc.y).applying(transform)
-        let nx = (transformed.x - trackBounds.minX) / trackBounds.width
-        let ny = 1 - (transformed.y - trackBounds.minY) / trackBounds.height
-        return CGPoint(x: nx * size.width, y: ny * size.height)
     }
 
     var body: some View {
         GeometryReader { geo in
-            let (points, bounds) = parseTrack()
-            let transform = locationTransform(trackBounds: bounds)
+            let points = trackPoints()
 
             if points.isEmpty {
                 Text("No coordinates available").foregroundColor(.red)
@@ -105,18 +63,16 @@ struct CircuitView: View {
                     }
                     .stroke(Color.blue, lineWidth: 2)
 
-                    if let transform = transform {
-                        ForEach(drivers) { driver in
-                            if let loc = driverPositions[driver.driver_number] {
-                                let p = point(for: loc, transform: transform, trackBounds: bounds, size: geo.size)
-                                Circle()
-                                    .fill(Color.red)
-                                    .frame(width: 8, height: 8)
-                                    .position(p)
-                                Text(driver.initials)
-                                    .font(.caption2)
-                                    .position(x: p.x, y: p.y - 10)
-                            }
+                    ForEach(viewModel.drivers) { driver in
+                        if let loc = viewModel.currentPosition[driver.driver_number] {
+                            let p = viewModel.point(for: loc, in: geo.size)
+                            Circle()
+                                .fill(Color.red)
+                                .frame(width: 8, height: 8)
+                                .position(p)
+                            Text(driver.initials)
+                                .font(.caption2)
+                                .position(x: p.x, y: p.y - 10)
                         }
                     }
                 }

--- a/F1App/F1App/HistoricalRaceViewModel.swift
+++ b/F1App/F1App/HistoricalRaceViewModel.swift
@@ -194,7 +194,8 @@ class HistoricalRaceViewModel: ObservableObject {
                         }
                     }
                     self.errorMessage = self.positions.isEmpty ? "Date de locație indisponibile" : nil
-                    if !self.hasInitialLocations, !self.positions.isEmpty {
+                    let totalLocations = self.positions.values.reduce(0) { $0 + $1.count }
+                    if !self.hasInitialLocations, totalLocations >= 2 {
                         self.calculateLocationBounds()
                         self.updatePositions()
                         self.hasInitialLocations = true
@@ -241,7 +242,7 @@ class HistoricalRaceViewModel: ObservableObject {
         locationTransform = t
     }
 
-    func point(for loc: LocationPoint, in size: CGSize) -> CGPoint {
+    public func point(for loc: LocationPoint, in size: CGSize) -> CGPoint {
         let transformed = CGPoint(x: loc.x, y: loc.y).applying(locationTransform)
         let nx = (transformed.x - trackBounds.minX) / trackBounds.width
         let ny = 1 - (transformed.y - trackBounds.minY) / trackBounds.height

--- a/F1App/F1App/RaceDetailView.swift
+++ b/F1App/F1App/RaceDetailView.swift
@@ -27,9 +27,7 @@ struct RaceDetailView: View {
             Spacer()
             
             if selectedTab == 0 {
-                CircuitView(coordinatesJSON: race.coordinates,
-                            drivers: viewModel.drivers,
-                            driverPositions: viewModel.currentPosition)
+                CircuitView(coordinatesJSON: race.coordinates, viewModel: viewModel)
                     .frame(height: UIScreen.main.bounds.height / 2)
                     .padding()
             } else if selectedTab == 1 {


### PR DESCRIPTION
## Summary
- Pass `HistoricalRaceViewModel` into `CircuitView` so it can compute driver points directly
- Remove local transformation logic from `CircuitView` and reuse `viewModel.point(for:in:)`
- Ensure location bounds are computed after receiving at least two locations and expose point method publicly

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_689e1504f58c832388c4c2ca48609cb2