### PR TITLE
Improve historical race rendering and cleanup

### DIFF
--- a/F1App/F1App/CircuitView.swift
+++ b/F1App/F1App/CircuitView.swift
@@ -8,76 +8,51 @@
 import SwiftUI
 
 struct CircuitView: View {
-    let coordinatesJSON: String?
     @ObservedObject var viewModel: HistoricalRaceViewModel
 
     init(coordinatesJSON: String?, viewModel: HistoricalRaceViewModel) {
-        self.coordinatesJSON = coordinatesJSON
         self.viewModel = viewModel
-    }
-
-    // Determine track points either from view model or by parsing JSON
-    func trackPoints() -> [CGPoint] {
-        if !viewModel.trackPoints.isEmpty {
-            return viewModel.trackPoints
-        }
-
-        guard
-            let jsonString = coordinatesJSON,
-            let data = jsonString.data(using: .utf8),
-            let arr = try? JSONSerialization.jsonObject(with: data) as? [[Double]],
-            !arr.isEmpty
-        else {
-            return []
-        }
-
-        let xs = arr.map { $0[0] }
-        let ys = arr.map { $0[1] }
-        let minX = xs.min() ?? 0
-        let maxX = xs.max() ?? 1
-        let minY = ys.min() ?? 0
-        let maxY = ys.max() ?? 1
-
-        return arr.map { point in
-            let x = (point[0] - minX) / (maxX - minX)
-            let y = 1 - (point[1] - minY) / (maxY - minY)
-            return CGPoint(x: x, y: y)
-        }
+        viewModel.ensureTrack(from: coordinatesJSON)
     }
 
     var body: some View {
-        GeometryReader { geo in
-            let points = trackPoints()
+        VStack {
+            GeometryReader { geo in
+                let points = viewModel.trackPoints
 
-            if points.isEmpty {
-                Text("No coordinates available").foregroundColor(.red)
-            } else {
-                ZStack {
-                    Path { path in
-                        let first = points[0]
-                        path.move(to: CGPoint(x: first.x * geo.size.width, y: first.y * geo.size.height))
-                        for point in points.dropFirst() {
-                            path.addLine(to: CGPoint(x: point.x * geo.size.width, y: point.y * geo.size.height))
+                if points.isEmpty {
+                    Text("No coordinates available").foregroundColor(.red)
+                } else {
+                    ZStack {
+                        Path { path in
+                            let first = points[0]
+                            path.move(to: CGPoint(x: first.x * geo.size.width, y: first.y * geo.size.height))
+                            for point in points.dropFirst() {
+                                path.addLine(to: CGPoint(x: point.x * geo.size.width, y: point.y * geo.size.height))
+                            }
+                            path.closeSubpath()
                         }
-                        path.closeSubpath()
-                    }
-                    .stroke(Color.blue, lineWidth: 2)
+                        .stroke(Color.blue, lineWidth: 2)
 
-                    ForEach(viewModel.drivers) { driver in
-                        if let loc = viewModel.currentPosition[driver.driver_number] {
-                            let p = viewModel.point(for: loc, in: geo.size)
-                            Circle()
-                                .fill(Color.red)
-                                .frame(width: 8, height: 8)
-                                .position(p)
-                            Text(driver.initials)
-                                .font(.caption2)
-                                .position(x: p.x, y: p.y - 10)
+                        ForEach(viewModel.drivers) { driver in
+                            if let loc = viewModel.currentPosition[driver.driver_number] {
+                                let p = viewModel.point(for: loc, in: geo.size)
+                                Circle()
+                                    .fill(Color.red)
+                                    .frame(width: 8, height: 8)
+                                    .position(p)
+                                Text(driver.initials)
+                                    .font(.caption2)
+                                    .position(x: p.x, y: p.y - 10)
+                            }
                         }
                     }
+                    .background(Color.gray.opacity(0.1))
+                    .cornerRadius(8)
                 }
-                .background(Color.gray.opacity(0.1))
-                .cornerRadius(8)
+            }
+            if let error = viewModel.errorMessage {
+                Text(error).foregroundColor(.red)
             }
         }
     }


### PR DESCRIPTION
## Summary
- Avoid calculating location bounds until distinct points are available and guard against zero-sized bounds
- Display an error if driver positions fall outside the drawing canvas
- Use `HistoricalRaceViewModel`'s parsed track data in `CircuitView`
- Invalidate race timer on view model deallocation

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_689e1e5701f8832395e8da8d04f25811