### PR TITLE
Add real-time playback with adjustable speed

### DIFF
--- a/F1App/F1App/HistoricalRaceView.swift
+++ b/F1App/F1App/HistoricalRaceView.swift
@@ -68,7 +68,7 @@ struct HistoricalRaceView: View {
                             }
                         }
                     }
-                    .animation(.linear(duration: 1), value: viewModel.stepIndex)
+                    .animation(.linear(duration: viewModel.currentStepDuration), value: viewModel.stepIndex)
                 }
                 .frame(height: 300)
                 .background(Color.gray.opacity(0.1))
@@ -93,8 +93,13 @@ struct HistoricalRaceView: View {
                     .padding(.horizontal)
                 }
 
-                Button(viewModel.isRunning ? "Pauză" : "Start") {
-                    viewModel.isRunning ? viewModel.pause() : viewModel.start()
+                HStack {
+                    Button(viewModel.isRunning ? "Pauză" : "Start") {
+                        viewModel.isRunning ? viewModel.pause() : viewModel.start()
+                    }
+                    Button("Viteză x\(Int(viewModel.playbackSpeed))") {
+                        viewModel.cycleSpeed()
+                    }
                 }
                 .padding(.bottom)
 


### PR DESCRIPTION
## Summary
- make historical race playback run in real time using timestamp intervals
- allow user to cycle playback speed between 1x, 2x, and 5x

## Testing
- `xcodebuild -scheme F1App -destination 'platform=iOS Simulator,name=iPhone 14' test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689e346b560483239815062a83f36690