### PR TITLE
Add start line and smooth race animation

### DIFF
--- a/F1App/F1App/HistoricalRaceView.swift
+++ b/F1App/F1App/HistoricalRaceView.swift
@@ -46,6 +46,15 @@ struct HistoricalRaceView: View {
                         }
                         .stroke(Color.blue, lineWidth: 2)
 
+                        if let startLoc = viewModel.positions[1]?.first {
+                            let startPoint = viewModel.point(for: startLoc, in: geo.size)
+                            Path { path in
+                                path.move(to: CGPoint(x: startPoint.x, y: startPoint.y - 10))
+                                path.addLine(to: CGPoint(x: startPoint.x, y: startPoint.y + 10))
+                            }
+                            .stroke(Color.green, lineWidth: 2)
+                        }
+
                         if !viewModel.currentPosition.isEmpty {
                             ForEach(viewModel.drivers) { driver in
                                 if let loc = viewModel.currentPosition[driver.driver_number] {
@@ -68,7 +77,7 @@ struct HistoricalRaceView: View {
                             }
                         }
                     }
-                    .animation(.linear(duration: viewModel.currentStepDuration), value: viewModel.stepIndex)
+                    .animation(.easeInOut(duration: viewModel.currentStepDuration), value: viewModel.stepIndex)
                 }
                 .frame(height: 300)
                 .background(Color.gray.opacity(0.1))

--- a/F1App/F1App/HistoricalRaceViewModel.swift
+++ b/F1App/F1App/HistoricalRaceViewModel.swift
@@ -296,7 +296,7 @@ class HistoricalRaceViewModel: ObservableObject {
         let scaled = interval / playbackSpeed
         currentStepDuration = scaled
         timer = Timer.scheduledTimer(withTimeInterval: scaled, repeats: false) { _ in
-            withAnimation(.linear(duration: self.currentStepDuration)) {
+            withAnimation(.easeInOut(duration: self.currentStepDuration)) {
                 self.stepIndex += 1
                 self.updatePositions()
             }


### PR DESCRIPTION
## Summary
- draw a start line at driver #1's initial coordinates
- use ease-in-out animation for smoother playback

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_689e707c20248323827fbed5076b143a