### PR TITLE
Colorize historical race markers by team

### DIFF
--- a/F1App/F1App/Color+Hex.swift
+++ b/F1App/F1App/Color+Hex.swift
@@ -1,0 +1,13 @@
+import SwiftUI
+
+extension Color {
+    init(hex: String) {
+        var hex = hex.trimmingCharacters(in: CharacterSet.alphanumerics.inverted)
+        var int: UInt64 = 0
+        Scanner(string: hex).scanHexInt64(&int)
+        let r = Double((int >> 16) & 0xFF) / 255.0
+        let g = Double((int >> 8) & 0xFF) / 255.0
+        let b = Double(int & 0xFF) / 255.0
+        self.init(red: r, green: g, blue: b)
+    }
+}

--- a/F1App/F1App/HistoricalRaceView.swift
+++ b/F1App/F1App/HistoricalRaceView.swift
@@ -52,7 +52,7 @@ struct HistoricalRaceView: View {
                                     let point = viewModel.point(for: loc, in: geo.size)
                                     if bounds.contains(point) {
                                         Circle()
-                                            .fill(Color.red)
+                                            .fill(Color(hex: driver.team_color ?? "FF0000"))
                                             .frame(width: 8, height: 8)
                                             .position(point)
                                         Text(driver.initials)

--- a/F1App/F1App/HistoricalRaceViewModel.swift
+++ b/F1App/F1App/HistoricalRaceViewModel.swift
@@ -10,11 +10,18 @@ struct Meeting: Decodable {
 struct DriverInfo: Identifiable, Decodable, Hashable {
     let driver_number: Int
     let full_name: String
+    let team_color: String?
 
     var id: Int { driver_number }
     var initials: String {
         let parts = full_name.split(separator: " ")
         return parts.compactMap { $0.first }.map { String($0) }.joined()
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case driver_number
+        case full_name
+        case team_color = "team_colour"
     }
 }
 


### PR DESCRIPTION
## Summary
- decode team color from OpenF1 driver data
- render historical race markers using each driver's team color
- add hex color initializer for SwiftUI Color

## Testing
- `swift build` (fails: Could not find Package.swift in this directory or any of its parent directories.)

------
https://chatgpt.com/codex/tasks/task_e_689f2415f4a48323bf0a9244cb3b1682