### PR TITLE
Delay driver telemetry requests until detail view appears

### DIFF
--- a/F1App/F1App/DriverDetailView.swift
+++ b/F1App/F1App/DriverDetailView.swift
@@ -31,6 +31,9 @@ struct DriverDetailView: View {
             .padding()
         }
         .navigationTitle(driver.initials)
+        .onAppear {
+            viewModel.fetchData()
+        }
     }
 }
 
@@ -50,7 +53,6 @@ class DriverDetailViewModel: ObservableObject {
     init(driver: DriverInfo, sessionKey: Int?) {
         self.driverNumber = driver.driver_number
         self.sessionKey = sessionKey
-        fetchData()
     }
 
     func fetchData() {


### PR DESCRIPTION
## Summary
- Trigger driver detail fetch when detail sheet opens
- Move API calls out of view model initializer

## Testing
- `swift --version`
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_689f2d45d4548323922b8be63ee25562