### PR TITLE
Add OpenF1 database query endpoint

### DIFF
--- a/API/F1_API/app/Http/Controllers/OpenF1Controller.php
+++ b/API/F1_API/app/Http/Controllers/OpenF1Controller.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+class OpenF1Controller extends Controller
+{
+    public function query(Request $request, string $table)
+    {
+        if (! Schema::connection('openf1')->hasTable($table)) {
+            return response()->json(['error' => 'Table not found'], 404);
+        }
+
+        $columnsParam = $request->query('columns');
+        $columns = ['*'];
+        if ($columnsParam) {
+            $columns = array_map('trim', explode(',', $columnsParam));
+            $invalid = array_filter($columns, function ($column) use ($table) {
+                return ! Schema::connection('openf1')->hasColumn($table, $column);
+            });
+
+            if ($invalid) {
+                return response()->json([
+                    'error' => 'Column not found',
+                    'columns' => array_values($invalid),
+                ], 400);
+            }
+        }
+
+        $data = DB::connection('openf1')->table($table)->select($columns)->get();
+
+        return response()->json($data);
+    }
+}
+

--- a/API/F1_API/routes/api.php
+++ b/API/F1_API/routes/api.php
@@ -7,6 +7,7 @@ use Illuminate\Http\Request;
 use App\Http\Controllers\Auth\PasswordController;
 use App\Http\Controllers\DriverController;
 use App\Http\Controllers\RaceController;
+use App\Http\Controllers\OpenF1Controller;
 
 Route::post('/login', [AuthController::class, 'login']);
 Route::post('/register', [AuthController::class, 'register']);
@@ -19,4 +20,6 @@ Route::middleware('auth:sanctum')->put('/password', [PasswordController::class, 
 Route::get('/drivers', [DriverController::class, 'index']);
 
 Route::get('/races', [RaceController::class, 'apiIndex'])->name('races.api');
+
+Route::get('/openf1/{table}', [OpenF1Controller::class, 'query']);
 


### PR DESCRIPTION
## Summary
- add OpenF1Controller for querying any table and columns from openf1 connection
- expose `/openf1/{table}` API route with optional column selection

## Testing
- `php artisan test` *(fails: Cannot redeclare class App\Providers\RouteServiceProvider)*

------
https://chatgpt.com/codex/tasks/task_e_68a07ba428b08323aaababb931d959f6