### PR TITLE
Persist API driver data and limit request rate

### DIFF
--- a/API/F1_API/app/Http/Controllers/DataController.php
+++ b/API/F1_API/app/Http/Controllers/DataController.php
@@ -2,23 +2,53 @@
 
 namespace App\Http\Controllers;
 
+use App\Models\Driver;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\RateLimiter;
 
 class DataController extends Controller
 {
-    public function fetchData()
+    public function fetchData(Request $request)
     {
-        // Înlocuiește cu URL-ul tău propriu dacă nu vrei să folosești JSONPlaceholder
-        $response = Http::get('https://jsonplaceholder.typicode.com/posts');
+        // Limităm endpoint-ul la maximum 10 cereri la fiecare 10 secunde per IP
+        $response = RateLimiter::attempt(
+            'fetch-data:' . $request->ip(),
+            10,
+            function () {
+                $response = Http::get('https://api.openf1.org/v1/drivers', [
+                    'meeting_key' => 1262,
+                ]);
 
-        // Verifică dacă răspunsul a fost cu succes (200 OK)
-        if ($response->successful()) {
-            $data = $response->json();
-            return response()->json($data);
+                if ($response->successful()) {
+                    $data = $response->json();
+
+                    foreach ($data as $driver) {
+                        $fullName = trim($driver['full_name'] ?? 'Unknown');
+
+                        Driver::updateOrCreate(
+                            ['name' => $fullName],
+                            [
+                                'team' => $driver['team_name'] ?? 'N/A',
+                                'points' => 0,
+                                'driver_number' => $driver['driver_number'] ?? 0,
+                                'country_code' => $driver['country_code'] ?? 'N/A',
+                            ]
+                        );
+                    }
+
+                    return response()->json(['status' => 'ok']);
+                }
+
+                return response()->json(['error' => 'Nu s-a putut obține datele'], 500);
+            },
+            10
+        );
+
+        if ($response === false) {
+            return response()->json(['error' => 'Too many requests'], 429);
         }
 
-        // Dacă API-ul returnează o eroare, afișează mesajul de eroare
-        return response()->json(['error' => 'Nu s-a putut obține datele'], 500);
+        return $response;
     }
 }


### PR DESCRIPTION
## Summary
- save OpenF1 driver data into the database using `Driver::updateOrCreate`
- throttle `fetchData` endpoint to 10 requests per 10 seconds and return 429 when exceeded

## Testing
- `php artisan test` *(fails: Cannot redeclare class App\Providers\RouteServiceProvider)*

------
https://chatgpt.com/codex/tasks/task_e_68a07df328f883239967a3bf92aa04bf