### PR TITLE
Add route and Artisan command to fetch OpenF1 data

### DIFF
--- a/API/F1_API/app/Console/Commands/FetchOpenF1Data.php
+++ b/API/F1_API/app/Console/Commands/FetchOpenF1Data.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use App\Http\Controllers\DataController;
+use Illuminate\Http\Request;
+
+class FetchOpenF1Data extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'fetch:openf1-data';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Fetch driver data from the OpenF1 API';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle()
+    {
+        $this->info('Fetching driver data from OpenF1...');
+
+        $controller = app(DataController::class);
+        $response = $controller->fetchData(new Request());
+
+        $this->info($response->getContent());
+
+        return Command::SUCCESS;
+    }
+}

--- a/API/F1_API/routes/api.php
+++ b/API/F1_API/routes/api.php
@@ -8,6 +8,7 @@ use App\Http\Controllers\Auth\PasswordController;
 use App\Http\Controllers\DriverController;
 use App\Http\Controllers\RaceController;
 use App\Http\Controllers\OpenF1Controller;
+use App\Http\Controllers\DataController;
 
 Route::post('/login', [AuthController::class, 'login']);
 Route::post('/register', [AuthController::class, 'register']);
@@ -18,6 +19,7 @@ Route::middleware('auth:sanctum')->post('/logout', function (Request $request) {
 });
 Route::middleware('auth:sanctum')->put('/password', [PasswordController::class, 'update_app']);
 Route::get('/drivers', [DriverController::class, 'index']);
+Route::post('/drivers/fetch', [DataController::class, 'fetchData']);
 
 Route::get('/races', [RaceController::class, 'apiIndex'])->name('races.api');
 


### PR DESCRIPTION
## Summary
- add `/drivers/fetch` POST route calling `DataController::fetchData`
- create `fetch:openf1-data` Artisan command invoking the controller

## Testing
- `php artisan test` *(fails: Cannot redeclare class App\Providers\RouteServiceProvider)*

------
https://chatgpt.com/codex/tasks/task_e_68a0bd63079c83239560c46cd84aa388