### PR TITLE
refactor: move driver fetch to job

### DIFF
--- a/API/F1_API/app/Http/Controllers/DataController.php
+++ b/API/F1_API/app/Http/Controllers/DataController.php
@@ -2,54 +2,15 @@
 
 namespace App\Http\Controllers;
 
-use App\Models\Driver;
+use App\Jobs\FetchDriversJob;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Http;
 
 class DataController extends Controller
 {
     public function fetchData(Request $request)
     {
-        $meetingsResponse = Http::get('https://api.openf1.org/v1/meetings', [
-            'year' => 2024,
-        ]);
+        FetchDriversJob::dispatch();
 
-        if (!$meetingsResponse->successful()) {
-            return response()->json(['error' => 'Nu s-au putut obține meeting-urile'], 500);
-        }
-
-        $meetings = $meetingsResponse->json();
-
-        foreach ($meetings as $meeting) {
-            $meetingKey = $meeting['meeting_key'] ?? null;
-
-            if (!$meetingKey) {
-                continue;
-            }
-
-            $driversResponse = Http::get('https://api.openf1.org/v1/drivers', [
-                'meeting_key' => $meetingKey,
-            ]);
-
-            if ($driversResponse->successful()) {
-                foreach ($driversResponse->json() as $driver) {
-                    $fullName = trim($driver['full_name'] ?? 'Unknown');
-
-                    Driver::updateOrCreate(
-                        ['name' => $fullName],
-                        [
-                            'team' => $driver['team_name'] ?? 'N/A',
-                            'points' => 0,
-                            'driver_number' => $driver['driver_number'] ?? 0,
-                            'country_code' => $driver['country_code'] ?? 'N/A',
-                        ]
-                    );
-                }
-            }
-
-            sleep(1);
-        }
-
-        return response()->json(['message' => 'Piloții au fost salvați']);
+        return response()->json(['message' => 'Driver fetch job dispatched']);
     }
 }

--- a/API/F1_API/app/Jobs/FetchDriversJob.php
+++ b/API/F1_API/app/Jobs/FetchDriversJob.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\Driver;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Http;
+
+class FetchDriversJob implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    /**
+     * Execute the job.
+     */
+    public function handle(): void
+    {
+        $meetingsResponse = Http::get('https://api.openf1.org/v1/meetings', [
+            'year' => 2024,
+        ]);
+
+        if (! $meetingsResponse->successful()) {
+            return;
+        }
+
+        foreach ($meetingsResponse->json() as $meeting) {
+            $meetingKey = $meeting['meeting_key'] ?? null;
+
+            if (! $meetingKey) {
+                continue;
+            }
+
+            $driversResponse = Http::get('https://api.openf1.org/v1/drivers', [
+                'meeting_key' => $meetingKey,
+            ]);
+
+            if ($driversResponse->successful()) {
+                foreach ($driversResponse->json() as $driver) {
+                    $fullName = trim($driver['full_name'] ?? 'Unknown');
+
+                    Driver::updateOrCreate(
+                        ['name' => $fullName],
+                        [
+                            'team' => $driver['team_name'] ?? 'N/A',
+                            'points' => 0,
+                            'driver_number' => $driver['driver_number'] ?? 0,
+                            'country_code' => $driver['country_code'] ?? 'N/A',
+                        ]
+                    );
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- offload driver fetching to `FetchDriversJob`
- dispatch job from `DataController`

## Testing
- ❌ `php artisan test` *(Cannot redeclare class App\Providers\RouteServiceProvider)*

------
https://chatgpt.com/codex/tasks/task_e_68a0bd658d208323a6ab6f21e1faeb7a