### PR TITLE
Use Laravel live endpoints

### DIFF
--- a/F1App/F1App/HistoricalRaceViewModel.swift
+++ b/F1App/F1App/HistoricalRaceViewModel.swift
@@ -2,11 +2,6 @@ import Foundation
 import SwiftUI
 import CoreLocation
 
-struct Meeting: Decodable {
-    let meeting_key: Int
-    let date_start: String
-}
-
 struct DriverInfo: Identifiable, Decodable, Hashable {
     let driver_number: Int
     let full_name: String
@@ -34,17 +29,9 @@ struct LocationPoint: Decodable {
     let y: Double
 }
 
-struct SessionInfo: Decodable {
-    let session_key: Int
-    let session_name: String
-    let date_start: String?
-    let date_end: String?
-}
-
 class HistoricalRaceViewModel: ObservableObject {
     @Published var year: String = ""
     @Published var errorMessage: String?
-    @Published var meeting: Meeting?
     @Published var drivers: [DriverInfo] = []
     @Published var positions: [Int: [LocationPoint]] = [:]
     @Published var currentPosition: [Int: LocationPoint] = [:]
@@ -56,6 +43,8 @@ class HistoricalRaceViewModel: ObservableObject {
     @Published var stepIndex: Int = 0
     @Published var playbackSpeed: Double = 1.0
     @Published var currentStepDuration: Double = 1.0
+    @Published var weather: SnapshotResponse.Weather?
+    @Published var raceControl: [SnapshotResponse.RaceControl] = []
 
     private var timer: Timer?
     private let speedOptions: [Double] = [1, 2, 5]
@@ -68,8 +57,7 @@ class HistoricalRaceViewModel: ObservableObject {
     }()
     private var trackBounds: CGRect = CGRect(x: 0, y: 0, width: 1, height: 1)
     private var locationBounds: CGRect = CGRect(x: 0, y: 0, width: 1, height: 1)
-    private var isFetchingLocations = false
-    private var hasInitialLocations = false
+    private var snapshotSince: String?
 
     func load(for race: Race) {
         pause()
@@ -77,11 +65,11 @@ class HistoricalRaceViewModel: ObservableObject {
         positions.removeAll()
         currentPosition.removeAll()
         parseTrack(race.coordinates)
-        guard let circuitId = race.circuit_id, let yearInt = Int(year) else {
+        guard let yearInt = Int(year) else {
             errorMessage = "Selectează un an valid"
             return
         }
-        fetchMeeting(circuitId: circuitId, year: yearInt)
+        resolveSession(meetingName: race.name, year: yearInt)
     }
 
     private func parseTrack(_ json: String?) {
@@ -105,34 +93,24 @@ class HistoricalRaceViewModel: ObservableObject {
         }
     }
 
-    private func fetchMeeting(circuitId: String, year: Int) {
-        guard let url = URL(string: "https://api.openf1.org/v1/meetings?circuit_key=\(circuitId)") else { return }
-        URLSession.shared.dataTask(with: url) { data, _, _ in
-            guard let data = data,
-                  let meetings = try? JSONDecoder().decode([Meeting].self, from: data),
-                  let meeting = meetings.first(where: { self.year(from: $0.date_start) == year }) else {
-                DispatchQueue.main.async {
-                    self.errorMessage = "Nu a fost cursa pe acel circuit in acel an"
-                }
-                return
-            }
-            DispatchQueue.main.async {
-                self.meeting = meeting
-                self.errorMessage = nil
-                self.fetchSession(meetingKey: meeting.meeting_key)
-            }
-        }.resume()
+    private struct ResolveResponse: Decodable {
+        let session_key: Int
+        let date_start: String?
+        let date_end: String?
     }
 
-    private func fetchSession(meetingKey: Int) {
-        guard let url = URL(string: "https://api.openf1.org/v1/sessions?meeting_key=\(meetingKey)&session_name=Race") else { return }
+    private func resolveSession(meetingName: String, year: Int) {
+        var comps = URLComponents(string: "http://localhost:8000/api/live/resolve")!
+        comps.queryItems = [
+            URLQueryItem(name: "year", value: String(year)),
+            URLQueryItem(name: "meeting_name", value: meetingName),
+            URLQueryItem(name: "session_type", value: "Race")
+        ]
+        guard let url = comps.url else { return }
         URLSession.shared.dataTask(with: url) { data, _, _ in
             guard let data = data,
-                  let sessions = try? JSONDecoder().decode([SessionInfo].self, from: data),
-                  let session = sessions.first else {
-                DispatchQueue.main.async {
-                    self.errorMessage = "Nu am găsit sesiunea pentru cursă"
-                }
+                  let session = try? JSONDecoder().decode(ResolveResponse.self, from: data) else {
+                DispatchQueue.main.async { self.errorMessage = "Nu am găsit sesiunea" }
                 return
             }
             DispatchQueue.main.async {
@@ -140,104 +118,124 @@ class HistoricalRaceViewModel: ObservableObject {
                 self.sessionStart = session.date_start
                 self.sessionEnd = session.date_end
                 self.errorMessage = nil
-                self.fetchDrivers(meetingKey: meetingKey, sessionKey: session.session_key)
+                self.fetchSnapshot()
             }
         }.resume()
     }
 
-    private func fetchDrivers(meetingKey: Int, sessionKey: Int) {
-        guard let url = URL(string: "https://api.openf1.org/v1/drivers?meeting_key=\(meetingKey)") else { return }
+    struct SnapshotResponse: Decodable {
+        struct Session: Decodable {
+            let session_key: Int
+            let meeting_key: Int
+            let status: String?
+            let server_time: String?
+        }
+        struct DriverEntry: Decodable {
+            struct Identity: Decodable {
+                let full_name: String
+                let team_name: String?
+                let team_colour: String?
+            }
+            struct Position: Decodable {
+                let position: Int?
+                let gap_to_leader: String?
+                let interval: String?
+                let date: String?
+            }
+            struct Lap: Decodable {
+                let lap_number: Int?
+                let lap_duration: String?
+                let date_start: String?
+            }
+            struct Car: Decodable {
+                let speed: Double?
+                let rpm: Double?
+                let throttle: Double?
+                let brake: Double?
+                let n_gear: Int?
+                let drs: Int?
+                let date: String?
+            }
+            struct Loc: Decodable {
+                let x: Double
+                let y: Double
+                let z: Double?
+                let date: String
+            }
+            let identity: Identity?
+            let position: Position?
+            let lap: Lap?
+            let car: Car?
+            let loc: Loc?
+        }
+        struct Weather: Decodable {
+            let air_temperature: Double?
+            let track_temperature: Double?
+            let humidity: Double?
+            let pressure: Double?
+            let wind_speed: Double?
+            let wind_direction: Double?
+            let rainfall: Double?
+            let date: String?
+        }
+        struct RaceControl: Decodable {
+            let flag: String?
+            let message: String?
+            let driver_number: Int?
+            let date: String?
+        }
+        let session: Session
+        let drivers: [String: DriverEntry]?
+        let weather: Weather?
+        let rc: [RaceControl]?
+        let since: String?
+    }
+
+    private func fetchSnapshot() {
+        guard let sessionKey = sessionKey else { return }
+        var comps = URLComponents(string: "http://localhost:8000/api/live/snapshot")!
+        comps.queryItems = [
+            URLQueryItem(name: "session_key", value: String(sessionKey)),
+            URLQueryItem(name: "fields", value: "drivers,position,lap,car,loc,weather,rc"),
+            URLQueryItem(name: "window_ms", value: "2000")
+        ]
+        if let since = snapshotSince {
+            comps.queryItems?.append(URLQueryItem(name: "since", value: since))
+        }
+        guard let url = comps.url else { return }
         URLSession.shared.dataTask(with: url) { data, _, _ in
             guard let data = data,
-                  let drivers = try? JSONDecoder().decode([DriverInfo].self, from: data) else { return }
-            let uniqueDrivers = Array(Set(drivers))
+                  let snap = try? JSONDecoder().decode(SnapshotResponse.self, from: data) else { return }
             DispatchQueue.main.async {
-                self.drivers = uniqueDrivers
-                self.fetchLocations(sessionKey: sessionKey)
-            }
-        }.resume()
-    }
-
-    private func fetchLocations(sessionKey: Int) {
-        let formatter = ISO8601DateFormatter()
-        guard let startString = sessionStart,
-              let start = formatter.date(from: startString) else { return }
-
-        let end: Date
-        if let endString = sessionEnd, let endDate = formatter.date(from: endString) {
-            end = endDate
-        } else {
-            end = start.addingTimeInterval(3 * 60 * 60)
-        }
-
-        positions.removeAll()
-        currentPosition.removeAll()
-        hasInitialLocations = false
-        isFetchingLocations = true
-
-        fetchLocationChunk(sessionKey: sessionKey, current: start, end: end, formatter: formatter)
-    }
-
-    private func fetchLocationChunk(sessionKey: Int, current: Date, end: Date, formatter: ISO8601DateFormatter) {
-        let step: TimeInterval = 5 * 60
-        let next = min(current.addingTimeInterval(step), end)
-
-        let startStr = formatter.string(from: current)
-        let endStr = formatter.string(from: next)
-        let urlString = "https://api.openf1.org/v1/location?session_key=\(sessionKey)&date>=\(startStr)&date<=\(endStr)"
-        guard let encoded = urlString.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed),
-              let url = URL(string: encoded) else {
-            if next < end {
-                fetchLocationChunk(sessionKey: sessionKey, current: next, end: end, formatter: formatter)
-            } else {
-                isFetchingLocations = false
-            }
-            return
-        }
-
-        URLSession.shared.dataTask(with: url) { data, _, error in
-            if let data = data, error == nil,
-               let locs = try? JSONDecoder().decode([LocationPoint].self, from: data) {
-                let grouped = Dictionary(grouping: locs, by: { $0.driver_number })
-
-                DispatchQueue.main.async {
-                    var exceededBounds = false
-                    for driver in self.drivers {
-                        if let arr = grouped[driver.driver_number], !arr.isEmpty {
-                            var existing = self.positions[driver.driver_number] ?? []
-                            let sortedArr = arr.sorted { $0.date < $1.date }
-                            existing.append(contentsOf: sortedArr)
-                            existing.sort { $0.date < $1.date }
-                            self.positions[driver.driver_number] = existing
-                            if self.currentPosition[driver.driver_number] == nil {
-                                self.currentPosition[driver.driver_number] = existing.first
-                            }
-                            if self.hasInitialLocations && !exceededBounds {
-                                for loc in sortedArr {
-                                    let p = CGPoint(x: loc.x, y: loc.y)
-                                    if !self.locationBounds.contains(p) {
-                                        exceededBounds = true
-                                        break
-                                    }
-                                }
-                            }
+                self.snapshotSince = snap.since
+                if let map = snap.drivers {
+                    for (key, value) in map {
+                        let dn = Int(key) ?? 0
+                        if let identity = value.identity,
+                           !self.drivers.contains(where: { $0.driver_number == dn }) {
+                            let info = DriverInfo(driver_number: dn,
+                                                   full_name: identity.full_name,
+                                                   team_color: identity.team_colour,
+                                                   team_name: identity.team_name)
+                            self.drivers.append(info)
+                        }
+                        if let loc = value.loc {
+                            let point = LocationPoint(driver_number: dn, date: loc.date, x: loc.x, y: loc.y)
+                            var arr = self.positions[dn] ?? []
+                            arr.append(point)
+                            self.positions[dn] = arr
+                            self.currentPosition[dn] = point
                         }
                     }
-                    self.errorMessage = self.positions.isEmpty ? "Date de locație indisponibile" : nil
-                    let totalLocations = self.positions.values.reduce(0) { $0 + $1.count }
-                    if !self.hasInitialLocations, totalLocations >= 2 {
-                        self.calculateLocationBounds()
-                        self.hasInitialLocations = true
-                    } else if self.hasInitialLocations && exceededBounds {
-                        self.calculateLocationBounds()
-                    }
+                    self.calculateLocationBounds()
                     self.updatePositions()
                 }
-            }
-            if next < end {
-                self.fetchLocationChunk(sessionKey: sessionKey, current: next, end: end, formatter: formatter)
-            } else {
-                DispatchQueue.main.async { self.isFetchingLocations = false }
+                if let weather = snap.weather {
+                    self.weather = weather
+                }
+                if let rc = snap.rc {
+                    self.raceControl.append(contentsOf: rc)
+                }
             }
         }.resume()
     }
@@ -314,10 +312,6 @@ class HistoricalRaceViewModel: ObservableObject {
     }
 
     private func timeIntervalForStep(_ index: Int) -> TimeInterval? {
-        // În loc să folosim doar primul pilot (care poate să nu aibă suficiente
-        // puncte de locație), căutăm orice pilot care are date pentru pasul
-        // curent și următor. Astfel, animația va porni chiar dacă primul pilot
-        // din listă nu are date complete.
         for arr in positions.values {
             if index + 1 < arr.count,
                let start = dateFormatter.date(from: arr[index].date),
@@ -333,3 +327,4 @@ class HistoricalRaceViewModel: ObservableObject {
         return Int(iso.prefix(4)) ?? 0
     }
 }
+


### PR DESCRIPTION
## Summary
- Replace OpenF1 calls with `/api/live/snapshot` in driver details.
- Add Laravel live resolve and snapshot integration for race playback with weather and race control parsing.

## Testing
- `swift --version`
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68a2120446288323b0fb8f498de6eb7c