### PR TITLE
Include meeting key in race data

### DIFF
--- a/API/F1_API/app/Http/Controllers/RaceController.php
+++ b/API/F1_API/app/Http/Controllers/RaceController.php
@@ -12,7 +12,10 @@ class RaceController extends Controller
     // API endpoint JSON
     public function apiIndex()
     {
-        $races = DB::table('races')->get()->map(fn($race) => $this->applyDynamicStatus($race));
+        $races = DB::table('races')
+            ->select('id', 'name', 'circuit_id', 'location', 'date', 'status', 'coordinates', 'meeting_key')
+            ->get()
+            ->map(fn($race) => $this->applyDynamicStatus($race));
         return response()->json($races);
     }
 

--- a/F1App/F1App/HistoricalRaceViewModel.swift
+++ b/F1App/F1App/HistoricalRaceViewModel.swift
@@ -69,7 +69,7 @@ class HistoricalRaceViewModel: ObservableObject {
             errorMessage = "Selectează un an valid"
             return
         }
-        resolveSession(meetingName: race.name, year: yearInt)
+        resolveSession(meetingKey: race.meeting_key, year: yearInt)
     }
 
     private func parseTrack(_ json: String?) {
@@ -99,11 +99,15 @@ class HistoricalRaceViewModel: ObservableObject {
         let date_end: String?
     }
 
-    private func resolveSession(meetingName: String, year: Int) {
+    private func resolveSession(meetingKey: Int?, year: Int) {
+        guard let meetingKey = meetingKey else {
+            errorMessage = "Lipsește meeting_key"
+            return
+        }
         var comps = URLComponents(string: "http://localhost:8000/api/live/resolve")!
         comps.queryItems = [
             URLQueryItem(name: "year", value: String(year)),
-            URLQueryItem(name: "meeting_name", value: meetingName),
+            URLQueryItem(name: "meeting_key", value: String(meetingKey)),
             URLQueryItem(name: "session_type", value: "Race")
         ]
         guard let url = comps.url else { return }

--- a/F1App/F1App/Models/Race.swift
+++ b/F1App/F1App/Models/Race.swift
@@ -8,6 +8,7 @@
 struct Race: Identifiable, Decodable {
     let id: Int
     let name: String
+    let meeting_key: Int?
     let circuit_id: String?
     let location: String
     let date: String


### PR DESCRIPTION
## Summary
- expose `meeting_key` through Race API and model
- use `meeting_key` to resolve historical sessions

## Testing
- `php artisan test` *(fails: Cannot redeclare class App\Providers\RouteServiceProvider)*
- `swift test` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*

------
https://chatgpt.com/codex/tasks/task_e_68a216c9b86483239571fd7ce8829f46