### PR TITLE
Add meeting key support for races

### DIFF
--- a/API/F1_API/app/Console/Commands/ImportRaces.php
+++ b/API/F1_API/app/Console/Commands/ImportRaces.php
@@ -39,6 +39,16 @@ class ImportRaces extends Command
                 ? Carbon::parse($race['date'])
                 : now();
             $status = $date->isFuture() ? 'upcoming' : 'finished';
+            $meetingKey = DB::connection('openf1')
+                ->table('meetings')
+                ->where('year', $date->year)
+                ->whereRaw('LOWER(meeting_name) LIKE ?', ['%' . strtolower($race['name']) . '%'])
+                ->value('meeting_key');
+
+            if (! $meetingKey) {
+                $this->warn("Meeting key not found for {$race['name']}.");
+            }
+
             $this->info("Saving race: " . $race['name']);
 
             DB::table('races')->updateOrInsert(
@@ -49,6 +59,7 @@ class ImportRaces extends Command
                     'date' => $date,
                     'status' => $status,
                     'coordinates' => $coordinates,
+                    'meeting_key' => $meetingKey,
                     'updated_at' => now(),
                     'created_at' => now(),
                 ]

--- a/API/F1_API/database/migrations/2025_06_10_000001_add_meeting_key_to_races_table.php
+++ b/API/F1_API/database/migrations/2025_06_10_000001_add_meeting_key_to_races_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('races', function (Blueprint $table) {
+            $table->unsignedBigInteger('meeting_key')->nullable()->after('circuit_id');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('races', function (Blueprint $table) {
+            $table->dropColumn('meeting_key');
+        });
+    }
+};

--- a/F1App/F1App/HistoricalRaceViewModel.swift
+++ b/F1App/F1App/HistoricalRaceViewModel.swift
@@ -38,6 +38,7 @@ class HistoricalRaceViewModel: ObservableObject {
     @Published var isRunning = false
     @Published var trackPoints: [CGPoint] = []
     @Published var sessionKey: Int?
+    @Published var meetingKey: Int?
     @Published var sessionStart: String?
     @Published var sessionEnd: String?
     @Published var stepIndex: Int = 0
@@ -69,7 +70,12 @@ class HistoricalRaceViewModel: ObservableObject {
             errorMessage = "Selectează un an valid"
             return
         }
-        resolveSession(meetingName: race.name, year: yearInt)
+        guard let mKey = race.meeting_key else {
+            errorMessage = "Lipsește meeting_key pentru cursă"
+            return
+        }
+        meetingKey = mKey
+        resolveSession(meetingKey: mKey, year: yearInt)
     }
 
     private func parseTrack(_ json: String?) {
@@ -99,11 +105,11 @@ class HistoricalRaceViewModel: ObservableObject {
         let date_end: String?
     }
 
-    private func resolveSession(meetingName: String, year: Int) {
+    private func resolveSession(meetingKey: Int, year: Int) {
         var comps = URLComponents(string: "http://localhost:8000/api/live/resolve")!
         comps.queryItems = [
             URLQueryItem(name: "year", value: String(year)),
-            URLQueryItem(name: "meeting_name", value: meetingName),
+            URLQueryItem(name: "meeting_key", value: String(meetingKey)),
             URLQueryItem(name: "session_type", value: "Race")
         ]
         guard let url = comps.url else { return }

--- a/F1App/F1App/Models/Race.swift
+++ b/F1App/F1App/Models/Race.swift
@@ -9,6 +9,7 @@ struct Race: Identifiable, Decodable {
     let id: Int
     let name: String
     let circuit_id: String?
+    let meeting_key: Int?
     let location: String
     let date: String
     let status: String


### PR DESCRIPTION
## Summary
- add `meeting_key` field to races table
- import meeting keys when seeding races
- propagate meeting key through iOS models and resolve live sessions via meeting_key

## Testing
- `php artisan test` *(fails: Cannot redeclare class App\Providers\RouteServiceProvider)*
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68a220284aac83239dc4ab6f65df0d15