### PR TITLE
Resolve historical session by circuit and date

### DIFF
--- a/API/F1_API/app/Console/Commands/ImportRaces.php
+++ b/API/F1_API/app/Console/Commands/ImportRaces.php
@@ -2,13 +2,14 @@
 
 namespace App\Console\Commands;
 
+use Carbon\Carbon;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\DB;
-use Carbon\Carbon;
 
 class ImportRaces extends Command
 {
     protected $signature = 'import:races';
+
     protected $description = 'Import F1 races with details and coordinates from local JSON files';
 
     public function handle()
@@ -19,7 +20,7 @@ class ImportRaces extends Command
         $races = json_decode(file_get_contents($jsonPath), true);
 
         foreach ($races as $race) {
-            $circuitId = $race['id']; // ex: it-1922
+            $circuitId = $race['circuit_id'] ?? $race['id'];
             $geoJsonPath = storage_path("app/data/circuits/{$circuitId}.geojson");
 
             $coordinates = null;
@@ -33,13 +34,13 @@ class ImportRaces extends Command
             } else {
                 $this->warn("Fișierul GEOJSON lipsește pentru {$circuitId}");
             }
-            $this->info('Număr curse în JSON: ' . count($races));
+            $this->info('Număr curse în JSON: '.count($races));
 
             $date = isset($race['date'])
                 ? Carbon::parse($race['date'])
                 : now();
             $status = $date->isFuture() ? 'upcoming' : 'finished';
-            $this->info("Saving race: " . $race['name']);
+            $this->info('Saving race: '.$race['name']);
 
             DB::table('races')->updateOrInsert(
                 ['circuit_id' => $circuitId],

--- a/API/F1_API/app/Http/Controllers/LiveController.php
+++ b/API/F1_API/app/Http/Controllers/LiveController.php
@@ -11,28 +11,21 @@ class LiveController extends Controller
 {
     public function resolveSession(Request $request)
     {
-        $year = (int) $request->query('year');
-        $meetingKey = $request->query('meeting_key');
-        $meetingName = $request->query('meeting_name');
+        $circuitId = $request->query('circuit_id');
+        $date = $request->query('date');
         $sessionType = $request->query('session_type', 'Race');
 
-        if (! $year || (! $meetingKey && ! $meetingName)) {
+        if (! $circuitId || ! $date) {
             return response()->json(['error' => 'Missing parameters'], 400);
         }
 
-        $query = DB::connection('openf1')->table('sessions')
+        $session = DB::connection('openf1')->table('sessions')
             ->select('sessions.session_key', 'sessions.meeting_key', 'sessions.session_type', 'sessions.date_start', 'sessions.date_end')
             ->join('meetings', 'sessions.meeting_key', '=', 'meetings.meeting_key')
-            ->where('meetings.year', $year)
-            ->where('sessions.session_type', $sessionType);
-
-        if ($meetingKey) {
-            $query->where('sessions.meeting_key', (int) $meetingKey);
-        } else {
-            $query->whereRaw('LOWER(meetings.meeting_name) LIKE ?', ['%' . strtolower($meetingName) . '%']);
-        }
-
-        $session = $query->first();
+            ->where('meetings.circuit_key', $circuitId)
+            ->whereDate('sessions.date_start', $date)
+            ->where('sessions.session_type', $sessionType)
+            ->first();
 
         if (! $session) {
             return response()->json(['error' => 'Session not found'], 404);
@@ -83,7 +76,7 @@ class LiveController extends Controller
         $response = new StreamedResponse(function () use ($sessionKey, $windowMs, $fields) {
             while (connection_aborted() === 0) {
                 $payload = $this->snapshotInternal($sessionKey, $windowMs, $fields, null);
-                echo 'data: ' . json_encode($payload) . "\n\n";
+                echo 'data: '.json_encode($payload)."\n\n";
                 ob_flush();
                 flush();
                 sleep(1);
@@ -274,4 +267,3 @@ class LiveController extends Controller
         return $out;
     }
 }
-

--- a/API/F1_API/storage/app/data/championships/f1-locations-2025.json
+++ b/API/F1_API/storage/app/data/championships/f1-locations-2025.json
@@ -1,6 +1,7 @@
 [
   {
     "id": "australian-grand-prix",
+    "circuit_id": "albert_park",
     "name": "Australian Grand Prix",
     "country": "Australia",
     "location": "Albert Park Circuit, Melbourne",
@@ -8,6 +9,7 @@
   },
   {
     "id": "chinese-grand-prix",
+    "circuit_id": "shanghai",
     "name": "Chinese Grand Prix",
     "country": "China",
     "location": "Shanghai International Circuit, Shanghai",
@@ -15,6 +17,7 @@
   },
   {
     "id": "japanese-grand-prix",
+    "circuit_id": "suzuka",
     "name": "Japanese Grand Prix",
     "country": "Japan",
     "location": "Suzuka Circuit, Suzuka",
@@ -22,6 +25,7 @@
   },
   {
     "id": "bahrain-grand-prix",
+    "circuit_id": "bahrain",
     "name": "Bahrain Grand Prix",
     "country": "Bahrain",
     "location": "Bahrain International Circuit, Sakhir",
@@ -29,6 +33,7 @@
   },
   {
     "id": "saudi-arabian-grand-prix",
+    "circuit_id": "jeddah",
     "name": "Saudi Arabian Grand Prix",
     "country": "Saudi Arabia",
     "location": "Jeddah Corniche Circuit, Jeddah",
@@ -36,6 +41,7 @@
   },
   {
     "id": "miami-grand-prix",
+    "circuit_id": "miami",
     "name": "Miami Grand Prix",
     "country": "United States",
     "location": "Miami International Autodrome, Miami Gardens, Florida",
@@ -43,6 +49,7 @@
   },
   {
     "id": "emilia-romagna-grand-prix",
+    "circuit_id": "imola",
     "name": "Emilia Romagna Grand Prix",
     "country": "Italy",
     "location": "Imola Circuit, Imola",
@@ -50,6 +57,7 @@
   },
   {
     "id": "monaco-grand-prix",
+    "circuit_id": "monaco",
     "name": "Monaco Grand Prix",
     "country": "Monaco",
     "location": "Circuit de Monaco, Monaco",
@@ -57,6 +65,7 @@
   },
   {
     "id": "spanish-grand-prix",
+    "circuit_id": "catalunya",
     "name": "Spanish Grand Prix",
     "country": "Spain",
     "location": "Circuit de Barcelona-Catalunya, Montmeló",
@@ -64,6 +73,7 @@
   },
   {
     "id": "canadian-grand-prix",
+    "circuit_id": "gilles_villeneuve",
     "name": "Canadian Grand Prix",
     "country": "Canada",
     "location": "Circuit Gilles Villeneuve, Montreal",
@@ -71,6 +81,7 @@
   },
   {
     "id": "austrian-grand-prix",
+    "circuit_id": "red_bull_ring",
     "name": "Austrian Grand Prix",
     "country": "Austria",
     "location": "Red Bull Ring, Spielberg",
@@ -78,6 +89,7 @@
   },
   {
     "id": "british-grand-prix",
+    "circuit_id": "silverstone",
     "name": "British Grand Prix",
     "country": "United Kingdom",
     "location": "Silverstone Circuit, Silverstone",
@@ -85,6 +97,7 @@
   },
   {
     "id": "belgian-grand-prix",
+    "circuit_id": "spa",
     "name": "Belgian Grand Prix",
     "country": "Belgium",
     "location": "Circuit de Spa-Francorchamps, Stavelot",
@@ -92,6 +105,7 @@
   },
   {
     "id": "hungarian-grand-prix",
+    "circuit_id": "hungaroring",
     "name": "Hungarian Grand Prix",
     "country": "Hungary",
     "location": "Hungaroring, Mogyoród",
@@ -99,6 +113,7 @@
   },
   {
     "id": "dutch-grand-prix",
+    "circuit_id": "zandvoort",
     "name": "Dutch Grand Prix",
     "country": "Netherlands",
     "location": "Circuit Zandvoort, Zandvoort",
@@ -106,6 +121,7 @@
   },
   {
     "id": "italian-grand-prix",
+    "circuit_id": "monza",
     "name": "Italian Grand Prix",
     "country": "Italy",
     "location": "Monza Circuit, Monza",
@@ -113,6 +129,7 @@
   },
   {
     "id": "azerbaijan-grand-prix",
+    "circuit_id": "baku",
     "name": "Azerbaijan Grand Prix",
     "country": "Azerbaijan",
     "location": "Baku City Circuit, Baku",
@@ -120,6 +137,7 @@
   },
   {
     "id": "singapore-grand-prix",
+    "circuit_id": "marina_bay",
     "name": "Singapore Grand Prix",
     "country": "Singapore",
     "location": "Marina Bay Street Circuit, Singapore",
@@ -127,6 +145,7 @@
   },
   {
     "id": "united-states-grand-prix",
+    "circuit_id": "americas",
     "name": "United States Grand Prix",
     "country": "United States",
     "location": "Circuit of the Americas, Austin, Texas",
@@ -134,6 +153,7 @@
   },
   {
     "id": "mexico-city-grand-prix",
+    "circuit_id": "rodriguez",
     "name": "Mexico City Grand Prix",
     "country": "Mexico",
     "location": "Autódromo Hermanos Rodríguez, Mexico City",
@@ -141,6 +161,7 @@
   },
   {
     "id": "sao-paulo-grand-prix",
+    "circuit_id": "interlagos",
     "name": "São Paulo Grand Prix",
     "country": "Brazil",
     "location": "Interlagos Circuit, São Paulo",
@@ -148,6 +169,7 @@
   },
   {
     "id": "las-vegas-grand-prix",
+    "circuit_id": "las_vegas",
     "name": "Las Vegas Grand Prix",
     "country": "United States",
     "location": "Las Vegas Strip Circuit, Paradise, Nevada",
@@ -155,6 +177,7 @@
   },
   {
     "id": "qatar-grand-prix",
+    "circuit_id": "losail",
     "name": "Qatar Grand Prix",
     "country": "Qatar",
     "location": "Lusail International Circuit, Lusail",
@@ -162,6 +185,7 @@
   },
   {
     "id": "abu-dhabi-grand-prix",
+    "circuit_id": "yas_marina",
     "name": "Abu Dhabi Grand Prix",
     "country": "United Arab Emirates",
     "location": "Yas Marina Circuit, Abu Dhabi",

--- a/F1App/F1App/HistoricalRaceView.swift
+++ b/F1App/F1App/HistoricalRaceView.swift
@@ -6,16 +6,6 @@ struct HistoricalRaceView: View {
 
     var body: some View {
         VStack {
-            HStack {
-                TextField("Anul", text: $viewModel.year)
-                    .keyboardType(.numberPad)
-                    .textFieldStyle(RoundedBorderTextFieldStyle())
-                Button("Caută") {
-                    viewModel.load(for: race)
-                }
-            }
-            .padding()
-
             if let error = viewModel.errorMessage {
                 Text(error)
                     .foregroundColor(.red)
@@ -123,6 +113,9 @@ struct HistoricalRaceView: View {
                 .frame(maxHeight: 200)
             }
             Spacer()
+        }
+        .onAppear {
+            viewModel.load(for: race)
         }
     }
 }

--- a/F1App/F1App/HistoricalRaceViewModel.swift
+++ b/F1App/F1App/HistoricalRaceViewModel.swift
@@ -30,7 +30,6 @@ struct LocationPoint: Decodable {
 }
 
 class HistoricalRaceViewModel: ObservableObject {
-    @Published var year: String = ""
     @Published var errorMessage: String?
     @Published var drivers: [DriverInfo] = []
     @Published var positions: [Int: [LocationPoint]] = [:]
@@ -65,11 +64,11 @@ class HistoricalRaceViewModel: ObservableObject {
         positions.removeAll()
         currentPosition.removeAll()
         parseTrack(race.coordinates)
-        guard let yearInt = Int(year) else {
-            errorMessage = "Selectează un an valid"
+        guard let circuitId = race.circuit_id else {
+            errorMessage = "ID circuit indisponibil"
             return
         }
-        resolveSession(meetingName: race.name, year: yearInt)
+        resolveSession(circuitId: circuitId, date: race.date)
     }
 
     private func parseTrack(_ json: String?) {
@@ -99,11 +98,11 @@ class HistoricalRaceViewModel: ObservableObject {
         let date_end: String?
     }
 
-    private func resolveSession(meetingName: String, year: Int) {
+    private func resolveSession(circuitId: String, date: String) {
         var comps = URLComponents(string: "http://localhost:8000/api/live/resolve")!
         comps.queryItems = [
-            URLQueryItem(name: "year", value: String(year)),
-            URLQueryItem(name: "meeting_name", value: meetingName),
+            URLQueryItem(name: "circuit_id", value: circuitId),
+            URLQueryItem(name: "date", value: date),
             URLQueryItem(name: "session_type", value: "Race")
         ]
         guard let url = comps.url else { return }
@@ -323,8 +322,5 @@ class HistoricalRaceViewModel: ObservableObject {
         return nil
     }
 
-    private func year(from iso: String) -> Int {
-        return Int(iso.prefix(4)) ?? 0
-    }
 }
 


### PR DESCRIPTION
## Summary
- look up OpenF1 sessions by `circuit_id` and date instead of meeting name/year
- remove manual year input and send `circuit_id` + `date` from HistoricalRaceView
- seed races with OpenF1 `circuit_id` values for session resolution

## Testing
- `php artisan test` *(fails: Cannot redeclare class App\Providers\RouteServiceProvider)*
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68a22f0521908323b2fed05008630a68