### PR TITLE
Wrap meetings API response in HistoricalRaceViewModel

### DIFF
--- a/F1App/F1App/HistoricalRaceViewModel.swift
+++ b/F1App/F1App/HistoricalRaceViewModel.swift
@@ -80,6 +80,10 @@ class HistoricalRaceViewModel: ObservableObject {
         let meeting_key: Int
     }
 
+    private struct MeetingsResponse: Decodable {
+        let data: [Meeting]
+    }
+
     private func fetchMeeting(year: Int, circuitKey: Int) {
         var comps = URLComponents(string: "http://127.0.0.1:8000/api/openf1/meetings")!
         comps.queryItems = [
@@ -88,9 +92,12 @@ class HistoricalRaceViewModel: ObservableObject {
         ]
         guard let url = comps.url else { return }
         URLSession.shared.dataTask(with: url) { data, _, _ in
-            guard let data = data,
-                  let meetings = try? JSONDecoder().decode([Meeting].self, from: data),
-                  let meeting = meetings.first else {
+            guard let data = data else {
+                DispatchQueue.main.async { self.errorMessage = "Nu am găsit cursa" }
+                return
+            }
+            let response = try? JSONDecoder().decode(MeetingsResponse.self, from: data)
+            guard let meeting = response?.data.first else {
                 DispatchQueue.main.async { self.errorMessage = "Nu am găsit cursa" }
                 return
             }


### PR DESCRIPTION
## Summary
- wrap meetings API response in MeetingsResponse struct
- decode meeting fetch through MeetingsResponse and continue with first meeting key

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68a2505a3ab4832394f8f58df2cac718