### PR TITLE
Add configurable API base URL

### DIFF
--- a/F1App/F1App/APIConfig.swift
+++ b/F1App/F1App/APIConfig.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+enum APIConfig {
+    /// Base URL for API requests.
+    /// - Note: When running on a physical device, update this value to your computer's local network IP.
+    static let baseURL = "http://127.0.0.1:8000"
+}
+

--- a/F1App/F1App/HistoricalRaceViewModel.swift
+++ b/F1App/F1App/HistoricalRaceViewModel.swift
@@ -82,7 +82,7 @@ class HistoricalRaceViewModel: ObservableObject {
     }
 
     private func fetchMeeting(year: Int, circuitKey: Int) {
-        var comps = URLComponents(string: "http://127.0.0.1:8000/api/openf1/meetings")!
+        var comps = URLComponents(string: "\(APIConfig.baseURL)/api/openf1/meetings")!
         comps.queryItems = [
             URLQueryItem(name: "year", value: String(year)),
             URLQueryItem(name: "circuit_key", value: String(circuitKey))
@@ -133,7 +133,7 @@ class HistoricalRaceViewModel: ObservableObject {
     }
 
     private func resolveSession(meetingKey: Int, year: Int) {
-        var comps = URLComponents(string: "http://127.0.0.1:8000/api/live/resolve")!
+        var comps = URLComponents(string: "\(APIConfig.baseURL)/api/live/resolve")!
         comps.queryItems = [
             URLQueryItem(name: "year", value: String(year)),
             URLQueryItem(name: "meeting_key", value: String(meetingKey)),
@@ -165,7 +165,7 @@ class HistoricalRaceViewModel: ObservableObject {
     }
 
     private func fetchDrivers(meetingKey: Int, sessionKey: Int) {
-        var comps = URLComponents(string: "http://127.0.0.1:8000/api/openf1/drivers")!
+        var comps = URLComponents(string: "\(APIConfig.baseURL)/api/openf1/drivers")!
         comps.queryItems = [URLQueryItem(name: "meeting_key", value: String(meetingKey))]
         guard let url = comps.url else { return }
         URLSession.shared.dataTask(with: url) { data, _, _ in
@@ -193,7 +193,7 @@ class HistoricalRaceViewModel: ObservableObject {
         let endStr = formatter.string(from: end)
         locationFetchCount = 0
         for driver in drivers {
-            var comps = URLComponents(string: "http://127.0.0.1:8000/api/openf1/location")!
+            var comps = URLComponents(string: "\(APIConfig.baseURL)/api/openf1/location")!
             comps.queryItems = [
                 URLQueryItem(name: "session_key", value: String(sessionKey)),
                 URLQueryItem(name: "driver_number", value: String(driver.driver_number)),

--- a/README.md
+++ b/README.md
@@ -1,1 +1,10 @@
 # Proiect nou
+
+## API Base URL
+
+The mobile app reads its server address from `F1App/F1App/APIConfig.swift`.
+
+- **Simulator:** the default value `http://127.0.0.1:8000` points to a server running on the same machine as the iOS Simulator.
+- **Physical device:** replace `baseURL` with your computer's IP address on the local network (e.g. `http://192.168.0.10:8000`) so the device can reach the development server.
+
+After updating the value, rebuild the app for the desired target.


### PR DESCRIPTION
## Summary
- centralize the API base URL in new `APIConfig`
- use `APIConfig.baseURL` in `HistoricalRaceViewModel` instead of hard-coded value
- document how to set the base URL for simulator and physical devices

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68a259e6fb708323ae19032e8ac4cfba