### PR TITLE
Implement live session resolution API and improve iOS client

### DIFF
--- a/API/F1_API/app/Http/Controllers/OpenF1Controller.php
+++ b/API/F1_API/app/Http/Controllers/OpenF1Controller.php
@@ -68,12 +68,20 @@ class OpenF1Controller extends Controller
             }
             $type = $schema->getColumnType($table, $base);
             if ($op === '__in') {
-                $vals = array_filter(array_map(function ($v) use ($type) {
+                $vals = array_filter(array_map(function ($v) use ($type, $base) {
+                    if ($base === 'date') {
+                        try { return Carbon::parse($v); } catch (\Throwable) { return null; }
+                    }
                     return $this->parseValue($type, $v);
                 }, explode(',', $value)));
                 $query->whereIn($base, $vals);
             } else {
-                $parsed = $this->parseValue($type, $value);
+                if ($base === 'date') {
+                    try { $parsed = Carbon::parse($value); }
+                    catch (\Throwable) { $parsed = $value; }
+                } else {
+                    $parsed = $this->parseValue($type, $value);
+                }
                 match ($op) {
                     '__gte' => $query->where($base, '>=', $parsed),
                     '__lte' => $query->where($base, '<=', $parsed),

--- a/F1App/F1App/APIConfig.swift
+++ b/F1App/F1App/APIConfig.swift
@@ -2,7 +2,10 @@ import Foundation
 
 enum APIConfig {
     /// Base URL for API requests.
-    /// - Note: When running on a physical device, update this value to your computer's local network IP.
-    static let baseURL = "http://127.0.0.1:8000"
+    /// Defaults to `http://127.0.0.1:8000` but can be overridden using
+    /// `UserDefaults.standard.set("http://192.168.1.10:8000", forKey: "api_base_url")`.
+    static var baseURL: String {
+        UserDefaults.standard.string(forKey: "api_base_url") ?? "http://127.0.0.1:8000"
+    }
 }
 

--- a/F1App/F1App/HistoricalRaceView.swift
+++ b/F1App/F1App/HistoricalRaceView.swift
@@ -75,8 +75,8 @@ struct HistoricalRaceView: View {
                 .cornerRadius(8)
                 .padding()
 
-                if viewModel.currentPosition.isEmpty {
-                    Text("Date de locație indisponibile")
+                if viewModel.currentPosition.isEmpty && viewModel.errorMessage == nil {
+                    Text("Date indisponibile")
                         .foregroundColor(.red)
                         .padding(.bottom)
                 }


### PR DESCRIPTION
## Summary
- extend live session resolution to use meeting key, circuit/date, or meeting name
- make date filtering robust in OpenF1 controller
- allow configurable base API URL and adjust historical race loading to use session_key with better error handling

## Testing
- `php artisan test` *(fails: Cannot redeclare class App\Providers\RouteServiceProvider)*

------
https://chatgpt.com/codex/tasks/task_e_68a37a6e9f34832396fe80259dddaec5