### PR TITLE
Force IPv4 base URL and remove localhost references

### DIFF
--- a/F1App/F1App/APIConfig.swift
+++ b/F1App/F1App/APIConfig.swift
@@ -2,10 +2,18 @@ import Foundation
 
 enum APIConfig {
     /// Base URL for API requests.
-    /// Defaults to `http://127.0.0.1:8000` but can be overridden using
+    /// Defaults depend on the build target but can be overridden using
     /// `UserDefaults.standard.set("http://192.168.1.10:8000", forKey: "api_base_url")`.
+    private static let defaultBaseURL: String = {
+        #if targetEnvironment(simulator)
+        return "http://127.0.0.1:8000"
+        #else
+        return "http://192.168.0.100:8000" // Replace with your Mac's LAN IP for physical device
+        #endif
+    }()
+
     static var baseURL: String {
-        UserDefaults.standard.string(forKey: "api_base_url") ?? "http://127.0.0.1:8000"
+        UserDefaults.standard.string(forKey: "api_base_url") ?? defaultBaseURL
     }
 }
 

--- a/F1App/F1App/DriverDetailView.swift
+++ b/F1App/F1App/DriverDetailView.swift
@@ -81,7 +81,7 @@ class DriverDetailViewModel: ObservableObject {
 
     private func fetchSnapshot() {
         guard let sessionKey = sessionKey else { return }
-        var components = URLComponents(string: "http://localhost:8000/api/live/snapshot")!
+        var components = URLComponents(string: "\(APIConfig.baseURL)/api/live/snapshot")!
         components.queryItems = [
             URLQueryItem(name: "session_key", value: String(sessionKey)),
             URLQueryItem(name: "fields", value: "position,lap,car,rc"),

--- a/F1App/F1App/RaceViewModel.swift
+++ b/F1App/F1App/RaceViewModel.swift
@@ -10,10 +10,10 @@ import Combine
 
 class RacesViewModel: ObservableObject {
     @Published var races = [Race]()
-    
+
     func fetchRaces() {
-        guard let url = URL(string: "http://localhost:8000/api/races") else { return }
-        
+        guard let url = URL(string: "\(APIConfig.baseURL)/api/races") else { return }
+
         URLSession.shared.dataTask(with: url) { data, response, error in
             if let data = data {
                 if let decoded = try? JSONDecoder().decode([Race].self, from: data) {


### PR DESCRIPTION
## Summary
- add build-target-aware API base URL to avoid IPv6 resolution issues
- use APIConfig.baseURL for race and driver detail requests

## Testing
- `xcodebuild -scheme F1App test` *(fails: command not found)*
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68a37e52bed48323bf2d805d49551672