### PR TITLE
Add debug diagnostics for historical race viewer

### DIFF
--- a/API/F1_API/app/Http/Controllers/HealthController.php
+++ b/API/F1_API/app/Http/Controllers/HealthController.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+
+class HealthController extends Controller
+{
+    public function index(Request $r)
+    {
+        $okDb = false; $err = null;
+        try {
+            DB::connection('openf1')->select('SELECT 1');
+            $okDb = true;
+        } catch (\Throwable $e) {
+            $err = $e->getMessage();
+        }
+
+        $sessionKey = $r->query('session_key');
+        $counts = null;
+        if ($okDb && $sessionKey) {
+            $c = fn($t) => DB::connection('openf1')->table($t)->where('session_key', (int)$sessionKey)->count();
+            $counts = [
+                'drivers'   => $c('drivers'),
+                'position'  => $c('position'),
+                'intervals' => $c('intervals'),
+                'car_data'  => $c('car_data'),
+                'location'  => $c('location'),
+                'weather'   => $c('weather'),
+                'race_ctrl' => $c('race_control'),
+                'laps'      => $c('laps'),
+            ];
+        }
+        return response()->json([
+            'status'   => 'ok',
+            'php'      => PHP_VERSION,
+            'db_openf1'=> $okDb ? 'ok' : 'fail',
+            'error'    => $err,
+            'counts'   => $counts,
+        ]);
+    }
+}

--- a/API/F1_API/routes/api.php
+++ b/API/F1_API/routes/api.php
@@ -9,6 +9,7 @@ use App\Http\Controllers\DriverController;
 use App\Http\Controllers\RaceController;
 use App\Http\Controllers\OpenF1Controller;
 use App\Http\Controllers\LiveController;
+use App\Http\Controllers\HealthController;
 
 Route::post('/login', [AuthController::class, 'login']);
 Route::post('/register', [AuthController::class, 'register']);
@@ -31,4 +32,5 @@ Route::get('/openf1/{table}', [OpenF1Controller::class, 'query']);
 Route::get('/live/resolve', [LiveController::class, 'resolveSession']);
 Route::get('/live/snapshot', [LiveController::class, 'snapshot']);
 Route::get('/live/stream', [LiveController::class, 'stream']);
+Route::get('/health', [HealthController::class, 'index']);
 

--- a/F1App/F1App/DebugLogView.swift
+++ b/F1App/F1App/DebugLogView.swift
@@ -1,0 +1,24 @@
+import SwiftUI
+
+struct DebugLogView: View {
+    @ObservedObject var logger: DebugLogger
+    var body: some View {
+        NavigationView {
+            List(logger.entries) { e in
+                VStack(alignment: .leading, spacing: 6) {
+                    Text(e.title).font(.headline)
+                    if !e.detail.isEmpty {
+                        Text(e.detail).font(.caption).foregroundColor(.secondary)
+                            .textSelection(.enabled)
+                            .lineLimit(nil)
+                    }
+                    Text(e.when).font(.caption2).foregroundColor(.gray)
+                }
+            }
+            .navigationTitle("Debug")
+            .toolbar {
+                Button("Clear") { logger.clear() }
+            }
+        }
+    }
+}

--- a/F1App/F1App/DebugLogger.swift
+++ b/F1App/F1App/DebugLogger.swift
@@ -1,0 +1,21 @@
+import Foundation
+import Combine
+
+struct DebugLogEntry: Identifiable {
+    let id = UUID()
+    let when = ISO8601DateFormatter().string(from: Date())
+    let title: String
+    let detail: String
+}
+
+final class DebugLogger: ObservableObject {
+    @Published var entries: [DebugLogEntry] = []
+    func log(_ title: String, _ detail: String = "") {
+        DispatchQueue.main.async {
+            self.entries.append(DebugLogEntry(title: title, detail: detail))
+            if self.entries.count > 500 { self.entries.removeFirst(self.entries.count - 500) }
+            print("📋 [DBG] \(title)\n\(detail)")
+        }
+    }
+    func clear() { entries.removeAll() }
+}

--- a/F1App/F1App/HistoricalRaceView.swift
+++ b/F1App/F1App/HistoricalRaceView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct HistoricalRaceView: View {
     let race: Race
     @ObservedObject var viewModel: HistoricalRaceViewModel
+    @State private var showDebug = false
 
     var body: some View {
         VStack {
@@ -100,6 +101,12 @@ struct HistoricalRaceView: View {
                     Button("Viteză x\(Int(viewModel.playbackSpeed))") {
                         viewModel.cycleSpeed()
                     }
+                    if viewModel.debugEnabled {
+                        Button("Diagnose") {
+                            viewModel.runDiagnosis(for: race)
+                            showDebug = true
+                        }
+                    }
                 }
                 .padding(.bottom)
 
@@ -123,6 +130,14 @@ struct HistoricalRaceView: View {
                 .frame(maxHeight: 200)
             }
             Spacer()
+        }
+        .sheet(isPresented: $showDebug) {
+            VStack {
+                if let sum = viewModel.diagnosisSummary {
+                    Text(sum).font(.headline).padding()
+                }
+                DebugLogView(logger: viewModel.logger)
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- Introduce `DebugLogger` and `DebugLogView` for capturing and displaying network logs
- Add optional debug mode in `HistoricalRaceViewModel` with `runDiagnosis` sequence and network request logging
- Integrate Diagnose button and log sheet into `HistoricalRaceView`
- Provide `/api/health` endpoint in Laravel backend for basic service and DB checks

## Testing
- `swiftc -typecheck F1App/F1App/DebugLogView.swift` *(fails: no such module 'SwiftUI')*
- `php artisan test` *(fails: Cannot redeclare class App\Providers\RouteServiceProvider)*

------
https://chatgpt.com/codex/tasks/task_e_68a3817458dc8323bde1b1e88d88dd0d