### PR TITLE
Allow overriding historical race year via user input

### DIFF
--- a/F1App/F1App/HistoricalRaceViewModel.swift
+++ b/F1App/F1App/HistoricalRaceViewModel.swift
@@ -82,15 +82,19 @@ class HistoricalRaceViewModel: ObservableObject {
             return
         }
 
-        // Derivează anul din data cursei (YYYY-MM-DD...)
-        let raceYear = Int(race.date.prefix(4)) ?? (Int(year) ?? 0)
-        if raceYear == 0 {
+        // Folosește anul introdus de utilizator dacă este valid, altfel extrage din data cursei
+        let selectedYear: Int
+        if !year.isEmpty, let userYear = Int(year) {
+            selectedYear = userYear
+        } else if let raceYear = Int(race.date.prefix(4)) {
+            selectedYear = raceYear
+        } else {
             errorMessage = "Data cursei invalidă"
             return
         }
 
         resolveSession(
-            year: raceYear,
+            year: selectedYear,
             meetingKey: nil,
             circuitKey: circuitKey,
             date: String(race.date.prefix(10))


### PR DESCRIPTION
## Summary
- Honor year entered by the user when loading historical races
- Pass the selected year into session resolution

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a38f9145648323aad5a297d80145c1