### PR TITLE
Use selected year when resolving session date

### DIFF
--- a/F1App/F1App/HistoricalRaceViewModel.swift
+++ b/F1App/F1App/HistoricalRaceViewModel.swift
@@ -93,11 +93,13 @@ class HistoricalRaceViewModel: ObservableObject {
             return
         }
 
+        let selectedDate = "\(selectedYear)\(race.date.dropFirst(4))"
+
         resolveSession(
             year: selectedYear,
             meetingKey: nil,
             circuitKey: circuitKey,
-            date: String(race.date.prefix(10))
+            date: selectedDate
         )
     }
 


### PR DESCRIPTION
## Summary
- Ensure HistoricalRaceViewModel builds session date by replacing the race's year with the user-selected year
- Pass constructed date to resolveSession for consistent year/date parameters

## Testing
- `swiftc F1App/F1App/HistoricalRaceViewModel.swift` *(fails: no such module 'SwiftUI')*
- `swift - <<'SWIFT' ... SWIFT`

------
https://chatgpt.com/codex/tasks/task_e_68a391969f248323a0c6ffa8f3820422