### PR TITLE
feat: add live snapshot and stream endpoints

### DIFF
--- a/API/F1_API/routes/api.php
+++ b/API/F1_API/routes/api.php
@@ -30,7 +30,7 @@ Route::get('/openf1/meetings/{meeting_key}/starting_grid', [OpenF1Controller::cl
 Route::get('/openf1/{table}', [OpenF1Controller::class, 'query']);
 
 Route::get('/live/resolve', [LiveController::class, 'resolveSession']);
-Route::get('/live/snapshot', [LiveController::class, 'snapshot']);
-Route::get('/live/stream', [LiveController::class, 'stream']);
+Route::get('/live/snapshot', [LiveController::class, 'snapshotAll']);
+Route::get('/live/stream',   [LiveController::class, 'stream']);
 Route::get('/health', [HealthController::class, 'index']);
 


### PR DESCRIPTION
## Summary
- expose consolidated /live/snapshot and /live/stream routes
- build per-driver state with latest telemetry and optional delta filtering
- stream live updates over SSE ticks

## Testing
- `php artisan test` *(fails: Cannot redeclare class App\Providers\RouteServiceProvider)*

------
https://chatgpt.com/codex/tasks/task_e_68a3a38311ac8323b75a9ecb88b41815