### PR TITLE
Expose driver stats from historic race map

### DIFF
--- a/F1App/F1App/DriverDetailView.swift
+++ b/F1App/F1App/DriverDetailView.swift
@@ -23,10 +23,11 @@ struct DriverDetailView: View {
                 Text("Position: \(viewModel.position)")
                 Text("RPM: \(viewModel.rpm)")
                 Text("Speed: \(viewModel.speed)")
+                Text("Acceleration: \(viewModel.acceleration)")
                 Text("Brake: \(viewModel.brake)")
+                Text("DRS: \(viewModel.drs)")
                 Text("Number of laps: \(viewModel.numberOfLaps)")
-           //     Text("DSQ: \(viewModel.dsq ? \"Yes\" : \"No\")")
-           //     Text("Compound: \(viewModel.compound)")
+                Text("DSQ: \(viewModel.dsq ? \"Yes\" : \"No\")")
             }
             .padding()
         }
@@ -39,7 +40,9 @@ class DriverDetailViewModel: ObservableObject {
     @Published var position: String = "-"
     @Published var rpm: String = "-"
     @Published var speed: String = "-"
+    @Published var acceleration: String = "-"
     @Published var brake: String = "-"
+    @Published var drs: String = "-"
     @Published var numberOfLaps: Int = 0
     @Published var dsq: Bool = false
     @Published var compound: String = "-"
@@ -66,6 +69,13 @@ class DriverDetailViewModel: ObservableObject {
                 let rpm: Double?
                 let speed: Double?
                 let brake: Double?
+                let throttle: Double?
+                let drs: Int?
+
+                enum CodingKeys: String, CodingKey {
+                    case rpm, speed, brake, throttle
+                    case drs = "drs_status"
+                }
             }
             let position: Position?
             let lap: Lap?
@@ -100,7 +110,9 @@ class DriverDetailViewModel: ObservableObject {
                 if let car = driverEntry.car {
                     if let rpm = car.rpm { self.rpm = String(Int(rpm)) }
                     if let speed = car.speed { self.speed = String(format: "%.1f", speed) }
+                    if let throttle = car.throttle { self.acceleration = String(format: "%.1f", throttle) }
                     if let brake = car.brake { self.brake = String(format: "%.1f", brake) }
+                    if let drs = car.drs { self.drs = drs == 1 ? "On" : "Off" }
                 }
                 if let lap = driverEntry.lap {
                     self.numberOfLaps = lap.lap_number ?? 0

--- a/F1App/F1App/HistoricalRaceView.swift
+++ b/F1App/F1App/HistoricalRaceView.swift
@@ -4,6 +4,7 @@ struct HistoricalRaceView: View {
     let race: Race
     @ObservedObject var viewModel: HistoricalRaceViewModel
     @State private var showDebug = false
+    @State private var selectedDriver: DriverInfo?
 
     var body: some View {
         VStack {
@@ -56,6 +57,9 @@ struct HistoricalRaceView: View {
                                             .fill(Color(hex: driver.team_color ?? "FF0000"))
                                             .frame(width: 8, height: 8)
                                             .position(point)
+                                            .onTapGesture {
+                                                selectedDriver = driver
+                                            }
                                         Text(driver.initials)
                                             .font(.caption2)
                                             .position(x: point.x, y: point.y - 10)
@@ -138,6 +142,9 @@ struct HistoricalRaceView: View {
                 }
                 DebugLogView(logger: viewModel.logger)
             }
+        }
+        .sheet(item: $selectedDriver) { driver in
+            DriverDetailView(driver: driver, sessionKey: viewModel.sessionKey)
         }
     }
 }


### PR DESCRIPTION
## Summary
- Allow tapping drivers on historical race map to open detailed driver view
- Show acceleration, DRS and disqualification status in the driver detail view

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68a3b74638b48323a3b4689265ae0c73