### PR TITLE
Pass LocationPoint to driver detail and fetch telemetry

### DIFF
--- a/F1App/F1App/CircuitView.swift
+++ b/F1App/F1App/CircuitView.swift
@@ -10,7 +10,12 @@ import SwiftUI
 struct CircuitView: View {
     let coordinatesJSON: String?
     @ObservedObject var viewModel: HistoricalRaceViewModel
-    @State private var selectedDriver: DriverInfo?
+    struct DriverSelection: Identifiable {
+        let driver: DriverInfo
+        let point: LocationPoint
+        var id: Int { driver.driver_number }
+    }
+    @State private var selectedDriver: DriverSelection?
 
     init(coordinatesJSON: String?, viewModel: HistoricalRaceViewModel) {
         self.coordinatesJSON = coordinatesJSON
@@ -68,7 +73,9 @@ struct CircuitView: View {
                         if let loc = viewModel.currentPosition[driver.driver_number] {
                             let p = viewModel.point(for: loc, in: geo.size)
                             Button {
-                                selectedDriver = driver
+                                if let loc = viewModel.currentPosition[driver.driver_number] {
+                                    selectedDriver = DriverSelection(driver: driver, point: loc)
+                                }
                             } label: {
                                 ZStack {
                                     Circle()
@@ -87,8 +94,10 @@ struct CircuitView: View {
                 .animation(.linear(duration: 1), value: viewModel.stepIndex)
                 .background(Color.gray.opacity(0.1))
                 .cornerRadius(8)
-                .sheet(item: $selectedDriver) { driver in
-                    DriverDetailView(driver: driver, sessionKey: viewModel.sessionKey)
+                .sheet(item: $selectedDriver) { selection in
+                    DriverDetailView(driver: selection.driver,
+                                     sessionKey: viewModel.sessionKey,
+                                     location: selection.point)
                 }
             }
         }

--- a/F1App/F1App/HistoricalRaceView.swift
+++ b/F1App/F1App/HistoricalRaceView.swift
@@ -4,7 +4,13 @@ struct HistoricalRaceView: View {
     let race: Race
     @ObservedObject var viewModel: HistoricalRaceViewModel
     @State private var showDebug = false
-    @State private var selectedDriver: DriverInfo?
+    struct DriverSelection: Identifiable {
+        let driver: DriverInfo
+        let point: LocationPoint
+        var id: Int { driver.driver_number }
+    }
+
+    @State private var selectedDriver: DriverSelection?
 
     var body: some View {
         VStack {
@@ -58,7 +64,7 @@ struct HistoricalRaceView: View {
                                             .frame(width: 8, height: 8)
                                             .position(point)
                                             .onTapGesture {
-                                                selectedDriver = driver
+                                                selectedDriver = DriverSelection(driver: driver, point: loc)
                                             }
                                         Text(driver.initials)
                                             .font(.caption2)
@@ -143,8 +149,10 @@ struct HistoricalRaceView: View {
                 DebugLogView(logger: viewModel.logger)
             }
         }
-        .sheet(item: $selectedDriver) { driver in
-            DriverDetailView(driver: driver, sessionKey: viewModel.sessionKey)
+        .sheet(item: $selectedDriver) { selection in
+            DriverDetailView(driver: selection.driver,
+                             sessionKey: viewModel.sessionKey,
+                             location: selection.point)
         }
     }
 }


### PR DESCRIPTION
## Summary
- propagate tapped LocationPoint from race map to driver detail view
- extend driver detail view model to fetch telemetry at a specific timestamp
- update circuit and historical views to support selection with timestamp

## Testing
- `swift test` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*


------
https://chatgpt.com/codex/tasks/task_e_68a3bb3a2dc48323b91c4a51601b1435