### PR TITLE
Use range query for telemetry and log errors

### DIFF
--- a/F1App/F1App/DriverDetailView.swift
+++ b/F1App/F1App/DriverDetailView.swift
@@ -78,27 +78,68 @@ class DriverDetailViewModel: ObservableObject {
 
     func fetchTelemetry(at timestamp: String) {
         guard let sessionKey = sessionKey else { return }
+
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
+
+        guard let startDate = formatter.date(from: timestamp) else {
+            print("Telemetry fetch error: invalid timestamp \(timestamp)")
+            return
+        }
+
+        let endDate = startDate.addingTimeInterval(1)
+        let endTimestamp = formatter.string(from: endDate)
+
         var comps = URLComponents(string: "\(APIConfig.baseURL)/api/openf1/car_data")!
         comps.queryItems = [
             URLQueryItem(name: "session_key", value: String(sessionKey)),
             URLQueryItem(name: "driver_number", value: String(driverNumber)),
-            URLQueryItem(name: "date", value: timestamp),
+            URLQueryItem(name: "date>=", value: timestamp),
+            URLQueryItem(name: "date<=", value: endTimestamp),
             URLQueryItem(name: "limit", value: "1")
         ]
         guard let url = comps.url else { return }
-        URLSession.shared.dataTask(with: url) { data, _, _ in
-            guard let data = data,
-                  let response = try? JSONDecoder().decode(TelemetryResponse.self, from: data),
-                  let telem = response.data.first else { return }
-            DispatchQueue.main.async {
-                if let rpm = telem.rpm { self.rpm = String(Int(rpm)) }
-                if let speed = telem.speed { self.speed = String(format: "%.1f", speed) }
-                if let throttle = telem.throttle { self.acceleration = String(format: "%.1f", throttle) }
-                if let brake = telem.brake { self.brake = String(format: "%.1f", brake) }
-                if let drs = telem.drs_status { self.drs = drs == 1 ? "On" : "Off" }
-                if let gap = telem.gap_to_leader { self.gapToLeader = gap }
-                if let pos = telem.position { self.position = String(pos) }
-                if let lap = telem.lap_number { self.numberOfLaps = lap }
+
+        URLSession.shared.dataTask(with: url) { data, response, error in
+            if let error = error {
+                print("Telemetry fetch error: \(error.localizedDescription)")
+                return
+            }
+
+            guard let httpResponse = response as? HTTPURLResponse else {
+                print("Telemetry fetch error: invalid response")
+                return
+            }
+
+            guard (200..<300).contains(httpResponse.statusCode) else {
+                print("Telemetry fetch failed: status code \(httpResponse.statusCode)")
+                return
+            }
+
+            guard let data = data else {
+                print("Telemetry fetch error: no data")
+                return
+            }
+
+            do {
+                let response = try JSONDecoder().decode(TelemetryResponse.self, from: data)
+                guard let telem = response.data.first else {
+                    print("Telemetry fetch: empty payload")
+                    return
+                }
+                DispatchQueue.main.async {
+                    if let rpm = telem.rpm { self.rpm = String(Int(rpm)) }
+                    if let speed = telem.speed { self.speed = String(format: "%.1f", speed) }
+                    if let throttle = telem.throttle { self.acceleration = String(format: "%.1f", throttle) }
+                    if let brake = telem.brake { self.brake = String(format: "%.1f", brake) }
+                    if let drs = telem.drs_status { self.drs = drs == 1 ? "On" : "Off" }
+                    if let gap = telem.gap_to_leader { self.gapToLeader = gap }
+                    if let pos = telem.position { self.position = String(pos) }
+                    if let lap = telem.lap_number { self.numberOfLaps = lap }
+                }
+            } catch {
+                print("Telemetry decode error: \(error.localizedDescription)")
             }
         }.resume()
     }


### PR DESCRIPTION
## Summary
- fetch telemetry using a timestamp range instead of an exact match
- log HTTP and decoding errors when telemetry fetch fails

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild -list` *(fails: command not found: xcodebuild)*

------
https://chatgpt.com/codex/tasks/task_e_68a3bfe3425483239603bac78208b0dc