### PR TITLE
Fix telemetry date filter names

### DIFF
--- a/F1App/F1App/DriverDetailView.swift
+++ b/F1App/F1App/DriverDetailView.swift
@@ -95,8 +95,8 @@ class DriverDetailViewModel: ObservableObject {
         comps.queryItems = [
             URLQueryItem(name: "session_key", value: String(sessionKey)),
             URLQueryItem(name: "driver_number", value: String(driverNumber)),
-            URLQueryItem(name: "date>=", value: timestamp),
-            URLQueryItem(name: "date<=", value: endTimestamp),
+            URLQueryItem(name: "date__gte", value: timestamp),
+            URLQueryItem(name: "date__lt", value: endTimestamp),
             URLQueryItem(name: "limit", value: "1")
         ]
         guard let url = comps.url else { return }


### PR DESCRIPTION
## Summary
- use backend-style `date__gte`/`date__lt` filters in telemetry query

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild -list` *(fails: command not found)*
- `curl 'https://api.openf1.org/v1/car_data?session_key=9154&driver_number=44&date__gte=2023-07-09T14:00:00Z&date__lt=2023-07-09T14:00:01Z&limit=1'` *(empty response)*

------
https://chatgpt.com/codex/tasks/task_e_68a3c31478e88323b90759a08f90ee43