### PR TITLE
Improve historical race telemetry handling

### DIFF
--- a/F1App/F1App/HistoricalRaceView.swift
+++ b/F1App/F1App/HistoricalRaceView.swift
@@ -87,7 +87,7 @@ struct HistoricalRaceView: View {
                 .padding()
 
                 if viewModel.currentPosition.isEmpty && viewModel.errorMessage == nil {
-                    Text("Date indisponibile")
+                    Text("Baza OpenF1 nu conține telemetrie pentru anul selectat")
                         .foregroundColor(.red)
                         .padding(.bottom)
                 }
@@ -139,6 +139,10 @@ struct HistoricalRaceView: View {
                 }
                 .frame(maxHeight: 200)
             }
+            Text("Telemetria pentru curse istorice este disponibilă doar pentru sezoanele recente. Dacă baza de date nu conține poziții pentru anul selectat, traseul nu poate fi afișat.")
+                .font(.footnote)
+                .foregroundColor(.secondary)
+                .padding()
             Spacer()
         }
         .sheet(isPresented: $showDebug) {


### PR DESCRIPTION
## Summary
- Resolve sessions even when `circuit_id` is missing by falling back to race name or date
- Clarify user feedback when telemetry is unavailable
- Batch and cache location requests for faster driver data retrieval

## Testing
- `swiftc -typecheck F1App/F1App/HistoricalRaceViewModel.swift F1App/F1App/HistoricalRaceView.swift` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_68a3c9c081d88323bb3fb61a43cd08ad