### PR TITLE
Add historical race streaming endpoint

### DIFF
--- a/API/F1_API/app/Http/Controllers/LiveController.php
+++ b/API/F1_API/app/Http/Controllers/LiveController.php
@@ -280,7 +280,7 @@ class LiveController extends Controller
         return $out;
     }
 
-    private function buildDriverState(int $sessionKey, ?string $sinceIso, array $fields, bool $onlyChanged): array
+    private function buildDriverState(int $sessionKey, ?string $sinceIso, array $fields, bool $onlyChanged, ?string $uptoIso = null): array
     {
         $includeLoc = in_array('loc', $fields, true);
         $includePos = in_array('pos', $fields, true);
@@ -296,12 +296,16 @@ class LiveController extends Controller
             ->keyBy('driver_number');
 
         $sinceFilter = ($onlyChanged && $sinceIso) ? $sinceIso : null;
+        $uptoFilter = $uptoIso;
 
         $latestLoc = collect();
         if ($includeLoc) {
             $baseLoc = $db->table('location')->where('session_key', $sessionKey);
             if ($sinceFilter) {
                 $baseLoc->where('date', '>', $sinceFilter);
+            }
+            if ($uptoFilter) {
+                $baseLoc->where('date', '<=', $uptoFilter);
             }
             $latestLocSub = $baseLoc
                 ->select('driver_number', DB::raw('MAX(date) as max_date'))
@@ -323,6 +327,9 @@ class LiveController extends Controller
             if ($sinceFilter) {
                 $basePos->where('date', '>', $sinceFilter);
             }
+            if ($uptoFilter) {
+                $basePos->where('date', '<=', $uptoFilter);
+            }
             $latestPosSub = $basePos
                 ->select('driver_number', DB::raw('MAX(date) as max_date'))
                 ->groupBy('driver_number');
@@ -342,6 +349,9 @@ class LiveController extends Controller
             $baseCar = $db->table('car_data')->where('session_key', $sessionKey);
             if ($sinceFilter) {
                 $baseCar->where('date', '>', $sinceFilter);
+            }
+            if ($uptoFilter) {
+                $baseCar->where('date', '<=', $uptoFilter);
             }
             $latestCarSub = $baseCar
                 ->select('driver_number', DB::raw('MAX(date) as max_date'))
@@ -413,8 +423,10 @@ class LiveController extends Controller
             $outDrivers[] = $state;
         }
 
+        $ts = $uptoIso ? Carbon::parse($uptoIso)->toIso8601String() : Carbon::now()->toIso8601String();
+
         return [
-            'ts' => Carbon::now()->toIso8601String(),
+            'ts' => $ts,
             'session_key' => $sessionKey,
             'drivers' => $outDrivers,
         ];
@@ -503,6 +515,66 @@ class LiveController extends Controller
                 @flush();
 
                 $since = $payload['ts'];
+                usleep($tickMs * 1000);
+            }
+        };
+
+        return response()->stream($callback, 200, $headers);
+    }
+
+    public function history(Request $request)
+    {
+        @ini_set('zlib.output_compression', '0');
+        @ini_set('implicit_flush', '1');
+        while (ob_get_level() > 0) { @ob_end_flush(); }
+        @set_time_limit(0);
+
+        $sessionKey = (int) $request->query('session_key');
+        if (! $sessionKey) {
+            return response('Missing session_key', 400);
+        }
+
+        $tickMs = max(200, (int) $request->query('tick_ms', 200));
+        $fieldsCsv = $request->query('fields', 'loc,pos,speed');
+        $fields = array_filter(array_map('trim', explode(',', $fieldsCsv)));
+
+        $db = DB::connection('openf1');
+        $startDate = $db->table('location')
+            ->where('session_key', $sessionKey)
+            ->min('date');
+        $endDate = $db->table('location')
+            ->where('session_key', $sessionKey)
+            ->max('date');
+        if (! $startDate || ! $endDate) {
+            return response('Session data not found', 404);
+        }
+
+        $start = Carbon::parse($startDate);
+        $end = Carbon::parse($endDate);
+
+        $headers = [
+            'Content-Type' => 'text/event-stream',
+            'Cache-Control' => 'no-cache',
+            'Connection' => 'keep-alive',
+            'X-Accel-Buffering' => 'no',
+        ];
+
+        $callback = function () use ($sessionKey, $fields, $tickMs, $start, $end) {
+            $ts = $start->copy();
+            while ($ts->lte($end)) {
+                try {
+                    $payload = $this->buildDriverState($sessionKey, null, $fields, false, $ts->toIso8601String());
+                } catch (\Throwable $e) {
+                    \Log::error($e);
+                    $payload = ['ts' => $ts->toIso8601String(), 'session_key' => $sessionKey, 'drivers' => []];
+                }
+
+                echo "event: tick\n";
+                echo 'data: ' . json_encode($payload) . "\n\n";
+                @ob_flush();
+                @flush();
+
+                $ts->addMilliseconds($tickMs);
                 usleep($tickMs * 1000);
             }
         };

--- a/API/F1_API/routes/api.php
+++ b/API/F1_API/routes/api.php
@@ -32,5 +32,6 @@ Route::get('/openf1/{table}', [OpenF1Controller::class, 'query']);
 Route::get('/live/resolve', [LiveController::class, 'resolveSession']);
 Route::get('/live/snapshot', [LiveController::class, 'snapshotAll']);
 Route::get('/live/stream',   [LiveController::class, 'stream']);
+Route::get('/live/history',  [LiveController::class, 'history']);
 Route::get('/health', [HealthController::class, 'index']);
 


### PR DESCRIPTION
## Summary
- allow driver state queries up to a specific timestamp
- add `/api/live/history` endpoint to replay sessions at 200ms intervals

## Testing
- `php artisan test` *(fails: Cannot redeclare class App\Providers\RouteServiceProvider)*

------
https://chatgpt.com/codex/tasks/task_e_68a47a3a5aa883238eda4285a0435598