### PR TITLE
Smooth historical race animation and keep telemetry running

### DIFF
--- a/F1App/F1App/HistoricalRaceView.swift
+++ b/F1App/F1App/HistoricalRaceView.swift
@@ -79,7 +79,7 @@ struct HistoricalRaceView: View {
                             }
                         }
                     }
-                    .animation(.linear(duration: viewModel.currentStepDuration), value: viewModel.stepIndex)
+                    .animation(.easeInOut(duration: viewModel.currentStepDuration), value: viewModel.stepIndex)
                 }
                 .frame(height: 300)
                 .background(Color.gray.opacity(0.1))

--- a/F1App/F1App/HistoricalRaceViewModel.swift
+++ b/F1App/F1App/HistoricalRaceViewModel.swift
@@ -356,13 +356,15 @@ class HistoricalRaceViewModel: ObservableObject {
         }
         let scaled = interval / playbackSpeed
         currentStepDuration = scaled
-        timer = Timer.scheduledTimer(withTimeInterval: scaled, repeats: false) { _ in
-            withAnimation(.linear(duration: self.currentStepDuration)) {
+        let newTimer = Timer(timeInterval: scaled, repeats: false) { _ in
+            withAnimation(.easeInOut(duration: self.currentStepDuration)) {
                 self.stepIndex += 1
                 self.updatePositions()
             }
             self.scheduleNextStep()
         }
+        RunLoop.main.add(newTimer, forMode: .common)
+        timer = newTimer
     }
 
     private func timeIntervalForStep(_ index: Int) -> TimeInterval? {


### PR DESCRIPTION
## Summary
- Smooth historical race animation with ease-in-out transitions
- Keep historical race timer active during telemetry by using a run loop in common mode

## Testing
- `swift build` *(fails: Could not find Package.swift)*
- `swiftc F1App/F1App/HistoricalRaceViewModel.swift -typecheck` *(fails: no such module 'SwiftUI')*


------
https://chatgpt.com/codex/tasks/task_e_68a4eb4f4dc88323840039f40b2374b9