### PR TITLE
Add historical playback API and SwiftUI playback client

### DIFF
--- a/API/F1_API/app/Http/Controllers/HistoricalController.php
+++ b/API/F1_API/app/Http/Controllers/HistoricalController.php
@@ -1,0 +1,250 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Carbon\Carbon;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Http;
+
+/**
+ * Endpoints used for historical session playback.
+ * Provides metadata, driver info and timed frames that can be consumed by
+ * clients for smooth race replays.
+ */
+class HistoricalController extends Controller
+{
+    /** Base URL for the public OpenF1 API. */
+    private string $openF1 = 'https://api.openf1.org/v1';
+
+    /**
+     * Resolve a session by year and circuit.
+     * Returns session_key, meeting_key and time bounds.
+     */
+    public function resolve(Request $request)
+    {
+        $year = (int) $request->query('year');
+        $circuitKey = (int) $request->query('circuit_key');
+        $sessionType = $request->query('session_type', 'Race');
+
+        if (! $year || ! $circuitKey) {
+            return response()->json(['error' => 'Missing parameters'], 400);
+        }
+
+        $response = Http::get($this->openF1 . '/sessions', [
+            'year' => $year,
+            'circuit_key' => $circuitKey,
+            'session_type' => $sessionType,
+            'limit' => 1,
+        ]);
+
+        if ($response->failed() || empty($response->json())) {
+            return response()->json(['error' => 'Session not found'], 404);
+        }
+
+        $session = $response->json()[0];
+
+        return response()->json([
+            'session_key' => $session['session_key'],
+            'meeting_key' => $session['meeting_key'],
+            'date_start' => $session['date_start'],
+            'date_end' => $session['date_end'],
+            'circuit_key' => $session['circuit_key'],
+        ]);
+    }
+
+    /**
+     * Provide a manifest describing all resources for the session.
+     */
+    public function manifest(int $sessionKey)
+    {
+        $session = Http::get($this->openF1 . '/sessions', ['session_key' => $sessionKey])->json()[0] ?? null;
+        if (! $session) {
+            return response()->json(['error' => 'Session not found'], 404);
+        }
+
+        $start = $session['date_start'];
+        $end = $session['date_end'];
+        $durationMs = Carbon::parse($start)->diffInMilliseconds(Carbon::parse($end));
+
+        return response()->json([
+            'session_key' => $sessionKey,
+            'time' => [
+                'start' => $start,
+                'end' => $end,
+                'duration_ms' => $durationMs,
+                'sample_rate_hz' => 5,
+            ],
+            'resources' => [
+                'drivers' => "/historical/session/$sessionKey/drivers",
+                'track'   => "/historical/session/$sessionKey/track",
+                'events'  => "/historical/session/$sessionKey/events",
+                'laps'    => "/historical/session/$sessionKey/laps",
+                'frames'  => [
+                    'by_time' => "/historical/session/$sessionKey/frames?t={iso8601}",
+                    'window'  => "/historical/session/$sessionKey/frames?from={iso}&to={iso}&stride_ms=200&format=ndjson",
+                ],
+            ],
+        ]);
+    }
+
+    /**
+     * Return driver metadata mapped to a compact DTO.
+     */
+    public function drivers(int $sessionKey)
+    {
+        $drivers = Http::get($this->openF1 . '/drivers', ['session_key' => $sessionKey])->json();
+
+        $mapped = collect($drivers)->map(function ($d) {
+            return [
+                'driver_number' => (string) $d['driver_number'],
+                'full_name' => trim(($d['first_name'] ?? '') . ' ' . ($d['last_name'] ?? '')),
+                'team_name' => $d['team_name'] ?? null,
+                'team_colour' => $d['team_colour'] ?? null,
+                'headshot_url' => $d['headshot_url'] ?? null,
+            ];
+        });
+
+        return response()->json($mapped);
+    }
+
+    /**
+     * Return basic track information including fixed bounds.
+     */
+    public function track(int $sessionKey)
+    {
+        $session = Http::get($this->openF1 . '/sessions', ['session_key' => $sessionKey])->json()[0] ?? null;
+        if (! $session) {
+            return response()->json(['error' => 'Session not found'], 404);
+        }
+
+        $track = [
+            'circuit_key' => $session['circuit_key'],
+            'name' => $session['circuit_short_name'] ?? $session['circuit_full_name'] ?? 'Unknown',
+            'map' => [
+                'image_url' => $session['circuit_map'] ?? '',
+                'bounds' => [
+                    'minX' => -5000,
+                    'minY' => -5000,
+                    'maxX' =>  5000,
+                    'maxY' =>  5000,
+                ],
+            ],
+        ];
+        return response()->json($track);
+    }
+
+    /** Proxy session events. */
+    public function events(int $sessionKey)
+    {
+        $data = Http::get($this->openF1 . '/events', ['session_key' => $sessionKey])->json();
+        return response()->json($data);
+    }
+
+    /** Proxy laps endpoint optionally filtered by driver number. */
+    public function laps(Request $request, int $sessionKey)
+    {
+        $query = ['session_key' => $sessionKey];
+        if ($driver = $request->query('driver_number')) {
+            $query['driver_number'] = $driver;
+        }
+        $data = Http::get($this->openF1 . '/laps', $query)->json();
+        return response()->json($data);
+    }
+
+    /**
+     * Provide frames either for a punctual timestamp or a window.
+     * Supports optional delta encoding and NDJSON streaming.
+     */
+    public function frames(int $sessionKey, Request $request)
+    {
+        $t = $request->query('t');
+        $from = $request->query('from');
+        $to = $request->query('to');
+        $strideMs = (int) $request->query('stride_ms', 200);
+        $include = array_filter(explode(',', $request->query('include', '')));
+        $format = $request->query('format', 'json');
+        $delta = filter_var($request->query('delta'), FILTER_VALIDATE_BOOLEAN);
+
+        if ($t) {
+            $frame = $this->buildFrame($sessionKey, Carbon::parse($t), $include);
+            return response()->json([$frame]);
+        }
+
+        if (! $from || ! $to) {
+            return response()->json(['error' => 'Missing time window'], 400);
+        }
+
+        $start = Carbon::parse($from);
+        $end = Carbon::parse($to);
+        $frames = [];
+        $prev = null;
+        for ($ts = $start->copy(); $ts->lte($end); $ts->addMilliseconds($strideMs)) {
+            $frame = $this->buildFrame($sessionKey, $ts, $include);
+            if ($delta && $prev) {
+                $frame['drivers'] = array_values(array_filter($frame['drivers'], function ($drv) use ($prev) {
+                    $n = $drv[0];
+                    $prevDrv = collect($prev['drivers'])->firstWhere(fn($d) => $d[0] === $n);
+                    return $prevDrv !== $drv;
+                }));
+            }
+            $frames[] = $frame;
+            $prev = $frame;
+        }
+
+        if ($format === 'ndjson') {
+            $headers = ['Content-Type' => 'application/x-ndjson'];
+            return response()->stream(function () use ($frames) {
+                foreach ($frames as $frame) {
+                    echo json_encode($frame) . "\n";
+                    @ob_flush();
+                    @flush();
+                }
+            }, 200, $headers);
+        }
+
+        return response()->json($frames);
+    }
+
+    /**
+     * Build a single frame for the given timestamp.
+     * Performs a simple nearest lookup on the OpenF1 location endpoint.
+     */
+    private function buildFrame(int $sessionKey, Carbon $ts, array $include): array
+    {
+        $params = [
+            'session_key' => $sessionKey,
+            'date' => $ts->toIso8601String(),
+        ];
+        $locations = Http::get($this->openF1 . '/location', $params)->json();
+
+        $drivers = [];
+        foreach ($locations as $loc) {
+            $entry = [
+                (string) $loc['driver_number'],
+                $loc['x'] ?? null,
+                $loc['y'] ?? null,
+            ];
+            if (in_array('speed', $include, true)) {
+                $entry[] = $loc['speed'] ?? null;
+            }
+            if (in_array('gear', $include, true)) {
+                $entry[] = $loc['n_gear'] ?? null;
+            }
+            $drivers[] = $entry;
+        }
+
+        $fields = ['n', 'x', 'y'];
+        if (in_array('speed', $include, true)) {
+            $fields[] = 'v';
+        }
+        if (in_array('gear', $include, true)) {
+            $fields[] = 'gear';
+        }
+
+        return [
+            't' => $ts->toIso8601String(),
+            'drivers' => $drivers,
+            'fields' => $fields,
+        ];
+    }
+}

--- a/API/F1_API/app/Providers/AppServiceProvider.php
+++ b/API/F1_API/app/Providers/AppServiceProvider.php
@@ -2,20 +2,17 @@
 
 namespace App\Providers;
 
-use Illuminate\Foundation\Support\Providers\RouteServiceProvider as ServiceProvider;
-use Illuminate\Support\Facades\Route;
+use Illuminate\Support\ServiceProvider;
 
-class RouteServiceProvider extends ServiceProvider
+class AppServiceProvider extends ServiceProvider
 {
-    public function boot()
+    public function register(): void
     {
-        $this->routes(function () {
-            Route::middleware('api')
-                ->prefix('api')
-                ->group(base_path('routes/api.php'));
+        //
+    }
 
-            Route::middleware('web')
-                ->group(base_path('routes/web.php'));
-        });
+    public function boot(): void
+    {
+        //
     }
 }

--- a/API/F1_API/app/Providers/RouteServiceProvider.php
+++ b/API/F1_API/app/Providers/RouteServiceProvider.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Providers;
+
+use Illuminate\Foundation\Support\Providers\RouteServiceProvider as ServiceProvider;
+use Illuminate\Support\Facades\Route;
+
+class RouteServiceProvider extends ServiceProvider
+{
+    public function boot()
+    {
+        $this->routes(function () {
+            Route::middleware('api')
+                ->prefix('api')
+                ->group(base_path('routes/api.php'));
+
+            Route::middleware('web')
+                ->group(base_path('routes/web.php'));
+        });
+    }
+}

--- a/API/F1_API/routes/api.php
+++ b/API/F1_API/routes/api.php
@@ -10,6 +10,7 @@ use App\Http\Controllers\RaceController;
 use App\Http\Controllers\OpenF1Controller;
 use App\Http\Controllers\LiveController;
 use App\Http\Controllers\HealthController;
+use App\Http\Controllers\HistoricalController;
 
 Route::post('/login', [AuthController::class, 'login']);
 Route::post('/register', [AuthController::class, 'register']);
@@ -33,5 +34,14 @@ Route::get('/live/resolve', [LiveController::class, 'resolveSession']);
 Route::get('/live/snapshot', [LiveController::class, 'snapshotAll']);
 Route::get('/live/stream',   [LiveController::class, 'stream']);
 Route::get('/live/history',  [LiveController::class, 'history']);
+Route::prefix('historical')->middleware('throttle:120,1')->group(function () {
+    Route::get('/resolve', [HistoricalController::class, 'resolve']);
+    Route::get('/session/{session_key}/manifest', [HistoricalController::class, 'manifest']);
+    Route::get('/session/{session_key}/drivers', [HistoricalController::class, 'drivers']);
+    Route::get('/session/{session_key}/track', [HistoricalController::class, 'track']);
+    Route::get('/session/{session_key}/events', [HistoricalController::class, 'events']);
+    Route::get('/session/{session_key}/laps', [HistoricalController::class, 'laps']);
+    Route::get('/session/{session_key}/frames', [HistoricalController::class, 'frames']);
+});
 Route::get('/health', [HealthController::class, 'index']);
 

--- a/API/F1_API/tests/Feature/HistoricalControllerTest.php
+++ b/API/F1_API/tests/Feature/HistoricalControllerTest.php
@@ -1,0 +1,97 @@
+<?php
+
+use Illuminate\Support\Facades\Http;
+use Carbon\Carbon;
+
+it('resolves session by year and circuit', function () {
+    Http::fake([
+        'https://api.openf1.org/v1/sessions*' => Http::response([
+            [
+                'session_key' => 9506,
+                'meeting_key' => 123,
+                'date_start' => '2024-05-04T15:00:00Z',
+                'date_end' => '2024-05-04T17:00:00Z',
+                'circuit_key' => 1,
+            ]
+        ], 200),
+    ]);
+
+    $response = $this->getJson('/api/historical/resolve?year=2024&circuit_key=1&session_type=Race');
+    $response->assertStatus(200)
+        ->assertJson([
+            'session_key' => 9506,
+            'meeting_key' => 123,
+            'circuit_key' => 1,
+        ]);
+});
+
+it('returns punctual frame', function () {
+    Http::fake([
+        'https://api.openf1.org/v1/location*' => Http::response([
+            ['driver_number' => '1', 'x' => 10, 'y' => 20, 'speed' => 250, 'n_gear' => 6],
+            ['driver_number' => '4', 'x' => 15, 'y' => 24, 'speed' => 240, 'n_gear' => 5],
+        ], 200),
+    ]);
+
+    $t = urlencode('2024-05-04T16:05:12Z');
+    $response = $this->getJson("/api/historical/session/9506/frames?t={$t}&include=speed,gear");
+    $response->assertStatus(200);
+    $json = $response->json();
+    expect($json)->toHaveCount(1);
+    expect($json[0]['drivers'][0])->toBe(['1', 10, 20, 250, 6]);
+    expect($json[0]['fields'])->toBe(['n','x','y','v','gear']);
+});
+
+it('returns window frames in json and ndjson', function () {
+    Http::fake([
+        'https://api.openf1.org/v1/location*' => Http::sequence()
+            ->push([
+                ['driver_number' => '1', 'x' => 1, 'y' => 1],
+                ['driver_number' => '2', 'x' => 2, 'y' => 2],
+            ], 200)
+            ->push([
+                ['driver_number' => '1', 'x' => 2, 'y' => 1],
+                ['driver_number' => '2', 'x' => 2, 'y' => 2],
+            ], 200)
+            ->push([
+                ['driver_number' => '1', 'x' => 3, 'y' => 1],
+                ['driver_number' => '2', 'x' => 2, 'y' => 2],
+            ], 200),
+    ]);
+
+    $from = urlencode('2024-05-04T16:00:00Z');
+    $to = urlencode('2024-05-04T16:00:00.400Z');
+
+    $jsonResp = $this->getJson("/api/historical/session/9506/frames?from={$from}&to={$to}&stride_ms=200");
+    $jsonResp->assertStatus(200);
+    expect($jsonResp->json())->toHaveCount(3);
+
+    $ndjson = $this->get("/api/historical/session/9506/frames?from={$from}&to={$to}&stride_ms=200&format=ndjson&delta=1");
+    $ndjson->assertStatus(200);
+    $lines = array_filter(explode("\n", trim($ndjson->getContent())));
+    expect($lines)->toHaveCount(3);
+});
+
+it('returns drivers and track info', function () {
+    Http::fake([
+        'https://api.openf1.org/v1/drivers*' => Http::response([
+            ['driver_number' => 1, 'first_name' => 'Max', 'last_name' => 'Verstappen', 'team_name' => 'Red Bull', 'team_colour' => '#3671C6', 'headshot_url' => 'http://example.com/img.jpg'],
+        ], 200),
+        'https://api.openf1.org/v1/sessions*' => Http::response([
+            ['circuit_key' => 1, 'circuit_short_name' => 'Test', 'circuit_map' => 'http://example.com/map.png'],
+        ], 200),
+    ]);
+
+    $drivers = $this->getJson('/api/historical/session/9506/drivers');
+    $drivers->assertStatus(200)
+        ->assertJson([
+            ['driver_number' => '1', 'full_name' => 'Max Verstappen'],
+        ]);
+
+    $track = $this->getJson('/api/historical/session/9506/track');
+    $track->assertStatus(200)
+        ->assertJson([
+            'circuit_key' => 1,
+            'map' => ['bounds' => ['minX' => -5000]],
+        ]);
+});

--- a/F1App/F1App/HistoricalStreamService.swift
+++ b/F1App/F1App/HistoricalStreamService.swift
@@ -1,0 +1,150 @@
+import Foundation
+
+/// Basic session info returned by /historical/resolve
+struct SessionInfo: Codable {
+    let session_key: Int
+    let meeting_key: Int
+    let date_start: String
+    let date_end: String
+    let circuit_key: Int
+}
+
+/// Manifest describing available resources for a session.
+struct Manifest: Codable {
+    struct TimeInfo: Codable { let start: String; let end: String; let duration_ms: Int; let sample_rate_hz: Int }
+    struct Resources: Codable {
+        let drivers: String
+        let track: String
+        let events: String
+        let laps: String
+        let frames: FrameEndpoints
+    }
+    struct FrameEndpoints: Codable { let by_time: String; let window: String }
+    let session_key: Int
+    let time: TimeInfo
+    let resources: Resources
+}
+
+/// Driver information mapped from OpenF1
+struct DriverDTO: Codable {
+    let driver_number: String
+    let full_name: String
+    let team_name: String?
+    let team_colour: String?
+    let headshot_url: String?
+}
+
+/// Frame representation used by playback.
+struct FrameDTO: Decodable {
+    let t: Date
+    let drivers: [[FieldValue]]
+    let fields: [String]
+
+    struct FieldValue: Decodable {
+        let string: String?
+        let double: Double?
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.singleValueContainer()
+            if let d = try? container.decode(Double.self) {
+                self.double = d
+                self.string = nil
+            } else if let s = try? container.decode(String.self) {
+                self.string = s
+                self.double = Double(s)
+            } else {
+                self.string = nil
+                self.double = nil
+            }
+        }
+    }
+}
+
+/// Service responsible for talking to the backend historical API.
+final class HistoricalStreamService {
+    private let baseURL: URL
+    private let decoder: JSONDecoder
+
+    init(baseURL: String = APIConfig.baseURL) {
+        self.baseURL = URL(string: baseURL)!
+        let d = JSONDecoder()
+        d.dateDecodingStrategy = .iso8601
+        self.decoder = d
+    }
+
+    /// Resolve a session using year and circuit key.
+    func resolve(year: Int, circuitKey: Int) async throws -> SessionInfo {
+        var comps = URLComponents(url: baseURL.appendingPathComponent("historical/resolve"), resolvingAgainstBaseURL: false)!
+        comps.queryItems = [
+            URLQueryItem(name: "year", value: String(year)),
+            URLQueryItem(name: "circuit_key", value: String(circuitKey)),
+            URLQueryItem(name: "session_type", value: "Race")
+        ]
+        let (data, _) = try await URLSession.shared.data(from: comps.url!)
+        return try decoder.decode(SessionInfo.self, from: data)
+    }
+
+    /// Download manifest for a session.
+    func manifest(sessionKey: Int) async throws -> Manifest {
+        let url = baseURL.appendingPathComponent("historical/session/\(sessionKey)/manifest")
+        let (data, _) = try await URLSession.shared.data(from: url)
+        return try decoder.decode(Manifest.self, from: data)
+    }
+
+    /// Fetch driver metadata.
+    func fetchDrivers(sessionKey: Int) async throws -> [DriverDTO] {
+        let url = baseURL.appendingPathComponent("historical/session/\(sessionKey)/drivers")
+        let (data, _) = try await URLSession.shared.data(from: url)
+        return try decoder.decode([DriverDTO].self, from: data)
+    }
+
+    /// Stream frames from the backend using NDJSON when possible.
+    func streamFrames(sessionKey: Int,
+                      from: Date,
+                      to: Date,
+                      strideMs: Int,
+                      drivers: [Int]? = nil,
+                      format: String = "ndjson",
+                      delta: Bool = false) async throws -> AsyncThrowingStream<FrameDTO, Error> {
+        var comps = URLComponents(url: baseURL.appendingPathComponent("historical/session/\(sessionKey)/frames"), resolvingAgainstBaseURL: false)!
+        var items: [URLQueryItem] = [
+            URLQueryItem(name: "from", value: ISO8601DateFormatter().string(from: from)),
+            URLQueryItem(name: "to", value: ISO8601DateFormatter().string(from: to)),
+            URLQueryItem(name: "stride_ms", value: String(strideMs)),
+            URLQueryItem(name: "format", value: format),
+        ]
+        if let drivers = drivers { items.append(URLQueryItem(name: "drivers", value: drivers.map(String.init).joined(separator: ","))) }
+        if delta { items.append(URLQueryItem(name: "delta", value: "1")) }
+        comps.queryItems = items
+        let url = comps.url!
+        var request = URLRequest(url: url)
+        request.addValue("application/x-ndjson", forHTTPHeaderField: "Accept")
+
+        if format == "ndjson" {
+            let (bytes, _) = try await URLSession.shared.bytes(for: request)
+            return AsyncThrowingStream { continuation in
+                Task {
+                    do {
+                        for try await line in bytes.lines {
+                            if line.isEmpty { continue }
+                            if let data = line.data(using: .utf8) {
+                                let frame = try decoder.decode(FrameDTO.self, from: data)
+                                continuation.yield(frame)
+                            }
+                        }
+                        continuation.finish()
+                    } catch {
+                        continuation.finish(throwing: error)
+                    }
+                }
+            }
+        } else {
+            let (data, _) = try await URLSession.shared.data(for: request)
+            let frames = try decoder.decode([FrameDTO].self, from: data)
+            return AsyncThrowingStream { continuation in
+                for frame in frames { continuation.yield(frame) }
+                continuation.finish()
+            }
+        }
+    }
+}

--- a/F1App/F1App/PlaybackViewModel.swift
+++ b/F1App/F1App/PlaybackViewModel.swift
@@ -1,0 +1,82 @@
+import Foundation
+import SwiftUI
+
+/// View model handling buffering and playback of historical frames.
+@MainActor final class PlaybackViewModel: ObservableObject {
+    @Published var isPlaying: Bool = false
+    @Published var speed: Double = 1.0
+    @Published var currentFrame: FrameDTO?
+
+    private let service = HistoricalStreamService()
+    private var buffer: [FrameDTO] = []
+    private var timer: Timer?
+    private var streamTask: Task<Void, Error>?
+    private var sessionKey: Int?
+    private let strideMs: Int = 200
+
+    /// Prepare streaming for a session.
+    func load(sessionKey: Int, from start: Date, to end: Date) {
+        self.sessionKey = sessionKey
+        prefetch(from: start, to: end)
+    }
+
+    /// Start playback.
+    func play() {
+        guard !isPlaying else { return }
+        isPlaying = true
+        scheduleTimer()
+    }
+
+    /// Pause playback.
+    func pause() {
+        isPlaying = false
+        timer?.invalidate()
+        timer = nil
+    }
+
+    /// Seek to a specific time and restart prefetch.
+    func seek(to time: Date) {
+        pause()
+        if let key = sessionKey {
+            buffer.removeAll()
+            prefetch(from: time, to: time.addingTimeInterval(10))
+        }
+    }
+
+    private func scheduleTimer() {
+        timer = Timer.scheduledTimer(withTimeInterval: Double(strideMs) / 1000.0 / speed, repeats: true) { [weak self] _ in
+            self?.tick()
+        }
+    }
+
+    private func tick() {
+        guard isPlaying else { return }
+        if buffer.isEmpty { return }
+        currentFrame = buffer.removeFirst()
+        if buffer.count < 5, let key = sessionKey, let last = currentFrame?.t {
+            let start = last.addingTimeInterval(Double(strideMs) / 1000.0)
+            let end = start.addingTimeInterval(4)
+            prefetch(from: start, to: end)
+        }
+    }
+
+    private func prefetch(from: Date, to: Date) {
+        guard let key = sessionKey else { return }
+        streamTask?.cancel()
+        streamTask = Task {
+            do {
+                let stream = try await service.streamFrames(sessionKey: key, from: from, to: to, strideMs: strideMs, format: "ndjson")
+                for try await frame in stream {
+                    buffer.append(frame)
+                }
+            } catch {
+                // TODO: handle streaming error
+            }
+        }
+    }
+
+    deinit {
+        streamTask?.cancel()
+        timer?.invalidate()
+    }
+}

--- a/F1App/F1App/PositionResampler.swift
+++ b/F1App/F1App/PositionResampler.swift
@@ -1,0 +1,166 @@
+import Foundation
+import simd
+
+/// Represents a single driver sample at a specific time.
+public struct PositionSample: Identifiable {
+    public let t: TimeInterval
+    public var x: Double
+    public var y: Double
+    public var v: Double?
+    public var gear: Int?
+    public var id: TimeInterval { t }
+
+    public init(t: TimeInterval, x: Double, y: Double, v: Double? = nil, gear: Int? = nil) {
+        self.t = t
+        self.x = x
+        self.y = y
+        self.v = v
+        self.gear = gear
+    }
+}
+
+/// Resamples irregular position data to a fixed stride and applies smoothing.
+public final class PositionResampler {
+    private let stride: TimeInterval
+    private let filterX: OneEuroFilter
+    private let filterY: OneEuroFilter
+
+    public init(stride: TimeInterval = 0.20) {
+        self.stride = stride
+        self.filterX = OneEuroFilter()
+        self.filterY = OneEuroFilter()
+    }
+
+    /// Resample the provided samples using linear/Catmull-Rom interpolation
+    /// and One-Euro filtering. No NaN/Inf values are produced.
+    public func resample(samples: [PositionSample]) -> [PositionSample] {
+        guard let first = samples.first, let last = samples.last else { return [] }
+        var result: [PositionSample] = []
+        var t = first.t
+        var idx = 0
+        var lastOut: PositionSample?
+        while t <= last.t {
+            while idx + 1 < samples.count && samples[idx + 1].t < t { idx += 1 }
+            var s = interpolate(at: t, index: idx, samples: samples)
+            // Smoothing
+            s.x = filterX.filter(value: s.x, timestamp: t)
+            s.y = filterY.filter(value: s.y, timestamp: t)
+            if let prev = lastOut {
+                let dx = s.x - prev.x
+                let dy = s.y - prev.y
+                if (dx*dx + dy*dy).squareRoot() > 400 { // outlier clamp
+                    filterX.reset(to: s.x, timestamp: t)
+                    filterY.reset(to: s.y, timestamp: t)
+                    s.x = filterX.last
+                    s.y = filterY.last
+                }
+            }
+            result.append(s)
+            lastOut = s
+            t += stride
+        }
+        return result
+    }
+
+    private func interpolate(at t: TimeInterval, index i: Int, samples: [PositionSample]) -> PositionSample {
+        let a = samples[i]
+        if i + 1 >= samples.count { return a }
+        let b = samples[i + 1]
+        let dt = b.t - a.t
+        if dt <= 0 { return b }
+        if dt > 1.0 { // big gap -> teleport
+            return PositionSample(t: t, x: b.x, y: b.y, v: b.v, gear: b.gear)
+        }
+        let u = (t - a.t) / dt
+        if i > 0 && i + 2 < samples.count {
+            let p0 = simd_double2(samples[i-1].x, samples[i-1].y)
+            let p1 = simd_double2(a.x, a.y)
+            let p2 = simd_double2(b.x, b.y)
+            let p3 = simd_double2(samples[i+2].x, samples[i+2].y)
+            let p = catmullRom(p0: p0, p1: p1, p2: p2, p3: p3, t: u)
+            return PositionSample(t: t, x: p.x, y: p.y, v: lerp(a.v, b.v, u), gear: b.gear)
+        } else {
+            let x = a.x + (b.x - a.x) * u
+            let y = a.y + (b.y - a.y) * u
+            return PositionSample(t: t, x: x, y: y, v: lerp(a.v, b.v, u), gear: b.gear)
+        }
+    }
+
+    private func catmullRom(p0: simd_double2, p1: simd_double2, p2: simd_double2, p3: simd_double2, t: Double) -> simd_double2 {
+        let t2 = t * t
+        let t3 = t2 * t
+        let a = -0.5 * t3 + t2 - 0.5 * t
+        let b = 1.5 * t3 - 2.5 * t2 + 1.0
+        let c = -1.5 * t3 + 2.0 * t2 + 0.5 * t
+        let d = 0.5 * t3 - 0.5 * t2
+        return a * p0 + b * p1 + c * p2 + d * p3
+    }
+
+    private func lerp(_ a: Double?, _ b: Double?, _ t: Double) -> Double? {
+        guard let a = a, let b = b else { return a ?? b }
+        return a + (b - a) * t
+    }
+}
+
+/// One-Euro filter implementation for smoothing noisy signals.
+final class OneEuroFilter {
+    private let minCutoff: Double
+    private let beta: Double
+    private let dCutoff: Double
+    private var lastTime: Double?
+    fileprivate let xFilter = LowPassFilter()
+    private let dxFilter = LowPassFilter()
+
+    init(minCutoff: Double = 1.2, beta: Double = 0.01, dCutoff: Double = 1.5) {
+        self.minCutoff = minCutoff
+        self.beta = beta
+        self.dCutoff = dCutoff
+    }
+
+    func filter(value: Double, timestamp: Double) -> Double {
+        guard value.isFinite else { return 0 }
+        if let last = lastTime {
+            let dt = timestamp - last
+            let edx = dxFilter.filter((value - xFilter.last)/max(dt, 1e-6), alpha: smoothingFactor(tau: 1.0/(2*Double.pi*dCutoff), dt: dt))
+            let cutoff = minCutoff + beta * abs(edx)
+            let alpha = smoothingFactor(tau: 1.0/(2*Double.pi*cutoff), dt: dt)
+            lastTime = timestamp
+            return xFilter.filter(value, alpha: alpha)
+        } else {
+            reset(to: value, timestamp: timestamp)
+            return value
+        }
+    }
+
+    func reset(to value: Double, timestamp: Double) {
+        lastTime = timestamp
+        xFilter.reset(to: value)
+        dxFilter.reset(to: 0)
+    }
+
+    private func smoothingFactor(tau: Double, dt: Double) -> Double {
+        let r = tau / max(dt, 1e-6)
+        return 1.0 / (1.0 + r)
+    }
+
+    final class LowPassFilter {
+        fileprivate var last: Double = 0
+        private var initialized = false
+
+        func filter(_ value: Double, alpha: Double) -> Double {
+            let a = max(0, min(1, alpha))
+            if !initialized {
+                initialized = true
+                last = value
+                return value
+            }
+            last = a * value + (1 - a) * last
+            return last
+        }
+
+        func reset(to value: Double) {
+            initialized = true
+            last = value
+        }
+    }
+}

--- a/F1App/F1App/TrackView.swift
+++ b/F1App/F1App/TrackView.swift
@@ -1,0 +1,58 @@
+import SwiftUI
+
+/// Draws driver markers on top of a static circuit map using the
+/// bounds provided by the backend. Guards against zero-sized layouts
+/// and uses small opacity transitions to avoid flicker.
+struct TrackView: View {
+    struct TrackInfo {
+        struct Bounds { let minX: Double; let minY: Double; let maxX: Double; let maxY: Double }
+        let imageURL: URL?
+        let bounds: Bounds
+    }
+    struct DriverPos: Identifiable {
+        let id: String
+        let x: Double
+        let y: Double
+        let color: Color
+    }
+
+    let track: TrackInfo
+    let drivers: [DriverPos]
+
+    var body: some View {
+        GeometryReader { geo in
+            if geo.size.width > 0 && geo.size.height > 0 {
+                ZStack {
+                    if let url = track.imageURL {
+                        AsyncImage(url: url) { img in
+                            img.resizable().aspectRatio(contentMode: .fit)
+                        } placeholder: {
+                            Color.black.opacity(0.1)
+                        }
+                    }
+                    ForEach(drivers) { d in
+                        Circle()
+                            .fill(d.color)
+                            .frame(width: 10, height: 10)
+                            .position(position(for: d, in: geo.size))
+                            .transition(.opacity)
+                            .animation(.linear(duration: 0.15), value: d.id)
+                    }
+                }
+            } else {
+                Color.clear
+            }
+        }
+    }
+
+    private func position(for driver: DriverPos, in size: CGSize) -> CGPoint {
+        let b = track.bounds
+        let w = max(b.maxX - b.minX, 1)
+        let h = max(b.maxY - b.minY, 1)
+        let sx = size.width / w
+        let sy = size.height / h
+        let x = (driver.x - b.minX) * sx
+        let y = size.height - (driver.y - b.minY) * sy
+        return CGPoint(x: x.isFinite ? x : 0, y: y.isFinite ? y : 0)
+    }
+}

--- a/F1App/F1AppTests/PositionResamplerTests.swift
+++ b/F1App/F1AppTests/PositionResamplerTests.swift
@@ -1,0 +1,35 @@
+import XCTest
+@testable import F1App
+
+final class PositionResamplerTests: XCTestCase {
+    func testLinearInterpolation() {
+        let r = PositionResampler(stride: 0.2)
+        let samples = [
+            PositionSample(t: 0, x: 0, y: 0),
+            PositionSample(t: 0.4, x: 4, y: 0)
+        ]
+        let out = r.resample(samples: samples)
+        XCTAssertEqual(out.count, 3)
+        XCTAssertEqual(out[1].x, 2, accuracy: 0.0001)
+    }
+
+    func testGapTeleport() {
+        let r = PositionResampler(stride: 0.2)
+        let samples = [
+            PositionSample(t: 0, x: 0, y: 0),
+            PositionSample(t: 1.5, x: 10, y: 0)
+        ]
+        let out = r.resample(samples: samples)
+        XCTAssertEqual(out[1].x, 10, accuracy: 0.0001)
+    }
+
+    func testOutlierClamp() {
+        let r = PositionResampler(stride: 0.2)
+        let samples = [
+            PositionSample(t: 0, x: 0, y: 0),
+            PositionSample(t: 0.2, x: 1000, y: 0)
+        ]
+        let out = r.resample(samples: samples)
+        XCTAssertEqual(out[1].x, 1000, accuracy: 0.0001)
+    }
+}

--- a/README.md
+++ b/README.md
@@ -8,3 +8,32 @@ The mobile app reads its server address from `F1App/F1App/APIConfig.swift`.
 - **Physical device:** replace `baseURL` with your computer's IP address on the local network (e.g. `http://192.168.0.10:8000`) so the device can reach the development server.
 
 After updating the value, rebuild the app for the desired target.
+
+## Historical playback API
+
+### Backend
+
+```bash
+cd API/F1_API
+composer install    # only first time
+php artisan serve   # starts Laravel backend on http://127.0.0.1:8000
+```
+
+The new historical endpoints live under `/api/historical` and expose:
+
+- `/historical/resolve`
+- `/historical/session/{session_key}/manifest`
+- `/historical/session/{session_key}/drivers`
+- `/historical/session/{session_key}/track`
+- `/historical/session/{session_key}/events`
+- `/historical/session/{session_key}/laps`
+- `/historical/session/{session_key}/frames`
+
+### iOS client
+
+Open `F1App/F1App.xcodeproj` in Xcode 15+. Ensure `APIConfig.baseURL`
+points to the backend server (see above). The client uses the new
+`HistoricalStreamService` to stream frames and `PlaybackViewModel` to
+control buffering and playback.
+
+Run unit tests with `swift test` or the Xcode test action.


### PR DESCRIPTION
## Summary
- expose /api/historical endpoints for resolving sessions and streaming frame data
- add HistoricalController with manifest, drivers, track and frame window support including optional NDJSON and delta
- implement SwiftUI client components: streaming service, position resampler with Catmull-Rom & One-Euro filter, playback view model and track view
- document backend start-up and client configuration

## Testing
- `php artisan test` *(fails: database file at path ... does not exist)*
- `php artisan test tests/Feature/HistoricalControllerTest.php` *(fails: expected 200 but received 404)*
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild -scheme F1App -project F1App.xcodeproj test` *(fails: command not found: xcodebuild)*

------
https://chatgpt.com/codex/tasks/task_e_68a4ee621a2c8323971e3251ca024527