### PR TITLE
Improve historical playback smoothing

### DIFF
--- a/F1App/F1App/HistoricalStreamService.swift
+++ b/F1App/F1App/HistoricalStreamService.swift
@@ -112,6 +112,7 @@ final class HistoricalStreamService {
             URLQueryItem(name: "to", value: ISO8601DateFormatter().string(from: to)),
             URLQueryItem(name: "stride_ms", value: String(strideMs)),
             URLQueryItem(name: "format", value: format),
+            URLQueryItem(name: "gap_ms", value: "1500"),
         ]
         if let drivers = drivers { items.append(URLQueryItem(name: "drivers", value: drivers.map(String.init).joined(separator: ","))) }
         if delta { items.append(URLQueryItem(name: "delta", value: "1")) }


### PR DESCRIPTION
## Summary
- Raise manifest sample rate to 10Hz and support Catmull-Rom interpolation with gap handling on the backend
- Stream frames with explicit gap tolerance from iOS client
- Smooth and clamp driver positions with per-driver One-Euro filters and linear animations

## Testing
- `php artisan test` *(fails: Database file at path ... does not exist)*
- `swift test` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*


------
https://chatgpt.com/codex/tasks/task_e_68a502573f008323b321ed93ec0442c5