### PR TITLE
Keep telemetry live during historical race

### DIFF
--- a/F1App/F1App/HistoricalRaceView.swift
+++ b/F1App/F1App/HistoricalRaceView.swift
@@ -6,7 +6,6 @@ struct HistoricalRaceView: View {
     @State private var showDebug = false
     struct DriverSelection: Identifiable {
         let driver: DriverInfo
-        let point: LocationPoint
         var id: Int { driver.driver_number }
     }
 
@@ -64,7 +63,7 @@ struct HistoricalRaceView: View {
                                             .frame(width: 8, height: 8)
                                             .position(point)
                                             .onTapGesture {
-                                                selectedDriver = DriverSelection(driver: driver, point: loc)
+                                                selectedDriver = DriverSelection(driver: driver)
                                             }
                                         Text(driver.initials)
                                             .font(.caption2)
@@ -152,7 +151,7 @@ struct HistoricalRaceView: View {
         .sheet(item: $selectedDriver) { selection in
             DriverDetailView(driver: selection.driver,
                              sessionKey: viewModel.sessionKey,
-                             location: selection.point)
+                             raceViewModel: viewModel)
         }
     }
 }


### PR DESCRIPTION
## Summary
- keep race playback running when viewing driver telemetry
- refresh telemetry continuously based on race step updates

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68a511c50d2c8323a16796b271e7edb3