### PR TITLE
Show race control details for historical races

### DIFF
--- a/F1App/F1App/HistoricalRaceView.swift
+++ b/F1App/F1App/HistoricalRaceView.swift
@@ -119,24 +119,17 @@ struct HistoricalRaceView: View {
                 }
                 .padding(.bottom)
 
-                List(viewModel.drivers) { driver in
-                    if let loc = viewModel.currentPosition[driver.driver_number] {
-                        HStack {
-                            Text(driver.full_name)
-                            Spacer()
-                            Text(String(format: "(%.2f, %.2f)", loc.x, loc.y))
-                                .font(.caption)
-                        }
-                    } else {
-                        HStack {
-                            Text(driver.full_name)
-                            Spacer()
-                            Text("N/A")
-                                .font(.caption)
+                if !viewModel.raceControlMessages.isEmpty {
+                    List(viewModel.raceControlMessages) { msg in
+                        VStack(alignment: .leading) {
+                            ForEach(msg.details.sorted(by: { $0.key < $1.key }), id: \.key) { key, value in
+                                Text("\(key): \(value)")
+                                    .font(.caption)
+                            }
                         }
                     }
+                    .frame(maxHeight: 200)
                 }
-                .frame(maxHeight: 200)
             }
             Spacer()
         }


### PR DESCRIPTION
## Summary
- replace driver list with race control messages in historical race view
- add RaceControlMessage model and network fetch to load race control data

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68a51c2d30148323b53604e5cd6e64a1