### PR TITLE
Filter race control messages to current minute only

### DIFF
--- a/F1App/F1App/HistoricalRaceViewModel.swift
+++ b/F1App/F1App/HistoricalRaceViewModel.swift
@@ -436,9 +436,11 @@ class HistoricalRaceViewModel: ObservableObject {
     private func updateRaceControlMessages() {
         guard !allRaceControlMessages.isEmpty else { return }
         guard let current = currentRaceDate() else { return }
+        let startOfMinute = Date(timeIntervalSinceReferenceDate: floor(current.timeIntervalSinceReferenceDate / 60) * 60)
+        let endOfMinute = startOfMinute.addingTimeInterval(60)
         raceControlMessages = allRaceControlMessages.filter { msg in
             if let dStr = msg.date, let d = dateFormatter.date(from: dStr) {
-                return d <= current
+                return d >= startOfMinute && d < endOfMinute
             }
             return false
         }


### PR DESCRIPTION
## Summary
- Filter race control updates to only include messages that occur within the current minute of the race playback

## Testing
- `swift build` *(fails: Could not find Package.swift)*
- `xcodebuild -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a5ab309b4083238fe4be9e9549e9b6