### PR TITLE
Use ISO8601 formatter for session times

### DIFF
--- a/F1App/F1App/HistoricalRaceViewModel.swift
+++ b/F1App/F1App/HistoricalRaceViewModel.swift
@@ -265,10 +265,8 @@ class HistoricalRaceViewModel: ObservableObject {
     }
 
     private func fetchLocations(sessionKey: Int) {
-        let backendFormatter = DateFormatter()
-        backendFormatter.dateFormat = "yyyy-MM-dd HH:mm:ss.SSSSSS"
-        backendFormatter.timeZone = TimeZone(secondsFromGMT: 0)
-        backendFormatter.locale = Locale(identifier: "en_US_POSIX")
+        let backendFormatter = ISO8601DateFormatter()
+        backendFormatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
 
         guard let startString = sessionStart,
               let start = backendFormatter.date(from: startString) else { return }


### PR DESCRIPTION
## Summary
- parse session start/end using ISO8601DateFormatter to honor API time zones
- build location queries with UTC-converted start/end times

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68a5b2fa038c83239a891c01a8747a54