### PR TITLE
Add overtake alerts to historical race replay

### DIFF
--- a/F1App/F1App/HistoricalRaceView.swift
+++ b/F1App/F1App/HistoricalRaceView.swift
@@ -91,6 +91,13 @@ struct HistoricalRaceView: View {
                         .padding(.bottom)
                 }
 
+                if let overtake = viewModel.overtakeMessage {
+                    Text(overtake)
+                        .padding(8)
+                        .background(Color.yellow.opacity(0.2))
+                        .cornerRadius(8)
+                }
+
                 if !viewModel.raceControlMessages.isEmpty {
                     List(viewModel.raceControlMessages) { msg in
                         HStack(alignment: .top) {


### PR DESCRIPTION
## Summary
- fetch overtake events from API and monitor playback position
- surface an overtake alert message below the track
- keep race control messages filtered to the current minute

## Testing
- ⚠️ `swift test` *(Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68a5dc5ee63c83239b10519dd7d3964f