### PR TITLE
Enable filtering F1 news by year

### DIFF
--- a/API/F1_API/app/Http/Controllers/NewsController.php
+++ b/API/F1_API/app/Http/Controllers/NewsController.php
@@ -11,8 +11,9 @@ class NewsController extends Controller
     {
         $days = (int) $request->query('days', 30);
         $limit = (int) $request->query('limit', 20);
+        $year = $request->query('year');
 
-        $items = $rss->fetch($days, $limit);
+        $items = $rss->fetch($days, $limit, $year ? (int) $year : null);
 
         return response()->json($items);
     }

--- a/API/F1_API/tests/Feature/NewsF1Test.php
+++ b/API/F1_API/tests/Feature/NewsF1Test.php
@@ -23,7 +23,7 @@ it('returns filtered and sorted news items', function () {
     });
 
     $controller = new NewsController();
-    $request = Request::create('/api/news/f1', 'GET', ['days' => 5, 'limit' => 5]);
+    $request = Request::create('/api/news/f1', 'GET', ['year' => 2025, 'limit' => 2]);
     $response = $controller->f1Autosport($request, $service);
 
     $data = $response->getData(true);

--- a/F1App/F1App/Services/NewsService.swift
+++ b/F1App/F1App/Services/NewsService.swift
@@ -11,10 +11,10 @@ final class NewsService {
         self.decoder = d
     }
 
-    func fetchF1News(days: Int = 30, limit: Int = 20) async throws -> [NewsItem] {
+    func fetchF1News(year: Int = 2025, limit: Int = 20) async throws -> [NewsItem] {
         var comps = URLComponents(url: baseURL.appendingPathComponent("api/news/f1"), resolvingAgainstBaseURL: false)!
         comps.queryItems = [
-            URLQueryItem(name: "days", value: String(days)),
+            URLQueryItem(name: "year", value: String(year)),
             URLQueryItem(name: "limit", value: String(limit))
         ]
         let (data, _) = try await URLSession.shared.data(from: comps.url!)


### PR DESCRIPTION
## Summary
- Allow querying Autosport RSS by year, enabling full-year news retrieval
- Expose `year` parameter on `/api/news/f1` and update Swift client accordingly
- Adjust News tests to reflect year-based filtering

## Testing
- `./vendor/bin/pest` *(fails: Database file at path [/workspace/F1_Manager/API/F1_API/database/database.sqlite] does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68a5e60356b4832387114965bc06ad94