### PR TITLE
Fetch full 2025 news feed on Home screen

### DIFF
--- a/F1App/F1App/HomeView.swift
+++ b/F1App/F1App/HomeView.swift
@@ -48,7 +48,8 @@ struct HomeView: View {
         isLoading = true
         error = nil
         do {
-            news = try await service.fetchF1News()
+            // Fetch all available news for the 2025 season
+            news = try await service.fetchF1News(year: 2025, limit: 365)
         } catch {
             self.error = "Eroare la încărcarea știrilor"
         }

--- a/F1App/F1App/Services/NewsService.swift
+++ b/F1App/F1App/Services/NewsService.swift
@@ -11,7 +11,7 @@ final class NewsService {
         self.decoder = d
     }
 
-    func fetchF1News(year: Int = 2025, limit: Int = 20) async throws -> [NewsItem] {
+    func fetchF1News(year: Int = 2025, limit: Int = 365) async throws -> [NewsItem] {
         var comps = URLComponents(url: baseURL.appendingPathComponent("api/news/f1"), resolvingAgainstBaseURL: false)!
         comps.queryItems = [
             URLQueryItem(name: "year", value: String(year)),


### PR DESCRIPTION
## Summary
- Fetch all available news for the 2025 season instead of only the most recent items
- Increase default news fetch limit to cover entire 2025 year

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68a5e7ab06f88323856eed3a6fc49e09