### PR TITLE
Limit news fetch size

### DIFF
--- a/F1App/F1App/HomeView.swift
+++ b/F1App/F1App/HomeView.swift
@@ -59,13 +59,12 @@ struct HomeView: View {
         info = nil
 
         let currentYear = Calendar.current.component(.year, from: Date())
-        let yearStart = Calendar.current.date(from: DateComponents(year: currentYear))!
-        let expectedCount = Calendar.current.range(of: .day, in: .year, for: yearStart)!.count
+        let limit = 30
 
         do {
-            news = try await service.fetchF1News(year: currentYear, limit: expectedCount)
-            if news.count < expectedCount {
-                info = "Doar \(news.count) știri disponibile pentru sezonul \(currentYear)."
+            news = try await service.fetchF1News(year: currentYear, limit: limit)
+            if news.count < limit {
+                info = "Doar \(news.count) din \(limit) știri disponibile pentru sezonul \(currentYear)."
             }
         } catch {
             self.error = "Eroare la încărcarea știrilor"


### PR DESCRIPTION
## Summary
- use fixed limit when loading F1 news
- show available count vs limit when fewer items are returned

## Testing
- `swift test` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*

------
https://chatgpt.com/codex/tasks/task_e_68a5f4ae68b48323aef5ca69cdf74e6e