### PR TITLE
Fix Autosport RSS feed caching and logging

### DIFF
--- a/API/F1_API/app/Http/Controllers/NewsController.php
+++ b/API/F1_API/app/Http/Controllers/NewsController.php
@@ -4,17 +4,23 @@ namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
 use App\Services\AutosportRss;
+use Illuminate\Support\Facades\Log;
 
 class NewsController extends Controller
 {
     public function f1Autosport(Request $request, AutosportRss $rss)
     {
-        $days = (int) $request->query('days', 30);
-        $limit = (int) $request->query('limit', 20);
-        $year = $request->query('year');
+        $days    = max(1, min((int)$request->query('days', 30), 365));
+        $limit   = max(1, min((int)$request->query('limit', 20), 50));
+        $year    = $request->query('year');
+        $nocache = $request->boolean('nocache', false);
 
-        $items = $rss->fetch($days, $limit, $year ? (int) $year : null);
+        $yearInt = $year !== null ? (int)$year : null;
+        Log::info('news.f1 params', ['days'=>$days,'limit'=>$limit,'year'=>$yearInt,'nocache'=>$nocache]);
 
-        return response()->json($items);
+        $items = $rss->fetch($days, $limit, $yearInt, $nocache);
+
+        Log::info('news.f1 final_count', ['count'=>count($items)]);
+        return response()->json($items, 200, [], JSON_UNESCAPED_UNICODE);
     }
 }

--- a/API/F1_API/app/Services/AutosportRss.php
+++ b/API/F1_API/app/Services/AutosportRss.php
@@ -5,6 +5,7 @@ namespace App\Services;
 use Carbon\Carbon;
 use GuzzleHttp\Client;
 use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
 
 class AutosportRss
@@ -24,51 +25,74 @@ class AutosportRss
      *
      * @return array<int, array<string, mixed>>
      */
-    public function fetch(int $days = 30, int $limit = 20, ?int $year = null): array
+    public function fetch(int $days = 30, int $limit = 20, ?int $year = null, bool $nocache = false): array
     {
+        // Fereastră de timp în UTC (robustă la TZ)
+        $now   = Carbon::now('UTC');
+        $start = $year ? Carbon::create($year, 1, 1, 0, 0, 0, 'UTC') : $now->copy()->subDays($days);
+        $end   = $year ? Carbon::create($year,12,31,23,59,59,'UTC')   : $now;
+
+        // Cheie de cache care include toți parametrii
         $cacheKey = $year
-            ? "autosport_f1_news_{$year}_{$limit}"
-            : "autosport_f1_news_{$days}_{$limit}";
+            ? "autosport_f1:year={$year}:limit={$limit}"
+            : "autosport_f1:days={$days}:limit={$limit}";
 
-        return Cache::remember($cacheKey, 3600, function () use ($days, $limit, $year) {
-            $response = $this->client->get($this->url);
-            $xml = new \SimpleXMLElement((string) $response->getBody());
+        $fetchFn = function () use ($start, $end, $limit) {
+            // User-Agent explicit — unele servere tratează diferit clienții fără UA
+            $response = $this->client->get($this->url, [
+                'headers' => ['User-Agent' => 'F1App/1.0 (+dev)']
+            ]);
+            $xmlStr = (string) $response->getBody();
+            $xml = @simplexml_load_string($xmlStr);
 
-            if ($year) {
-                $start = Carbon::create($year, 1, 1)->startOfDay();
-                $end = Carbon::create($year, 12, 31)->endOfDay();
-            } else {
-                $start = Carbon::now()->subDays($days);
-                $end = Carbon::now();
+            if (!$xml || !isset($xml->channel->item)) {
+                Log::warning('autosport.fetch xml_invalid');
+                return [];
             }
 
-            $items = collect(iterator_to_array($xml->channel->item ?? []))->map(function ($item) {
-                $link = (string) $item->link;
+            // ✅ Normalizează lista de <item> (evită iterator_to_array capricios)
+            $list = [];
+            foreach ($xml->channel->item as $it) { $list[] = $it; }
+            Log::info('autosport.fetch.before', ['raw' => count($list)]);
+
+            $items = collect($list)->map(function ($item) {
+                // Imagine din <media:content> sau <enclosure>, opțională
                 $image = null;
                 $media = $item->children('media', true);
-                if ($media && $media->content) {
+                if ($media && $media->content && $media->content->attributes()->url) {
                     $image = (string) $media->content->attributes()->url;
-                } elseif ($item->enclosure) {
+                } elseif (isset($item->enclosure) && $item->enclosure['url']) {
                     $image = (string) $item->enclosure['url'];
                 }
-                $description = trim(strip_tags((string) $item->description));
-                $excerpt = Str::limit($description, 280, '');
+
+                $link = (string) $item->link;
+                $desc = Str::of((string)$item->description)->stripTags()->squish();
 
                 return [
-                    'id' => md5($link),
-                    'title' => (string) $item->title,
-                    'link' => $link,
-                    'published_at' => Carbon::parse((string) $item->pubDate)->utc()->toIso8601String(),
-                    'image_url' => $image ?: null,
-                    'source' => 'Autosport',
-                    'excerpt' => $excerpt,
+                    'id'           => md5($link),
+                    'title'        => (string) $item->title,
+                    'link'         => $link,
+                    'published_at' => Carbon::parse((string)$item->pubDate)->utc()->toIso8601String(),
+                    'image_url'    => $image ?: null,
+                    'source'       => 'Autosport',
+                    'excerpt'      => Str::limit($desc, 240),
                 ];
-            })->filter(function ($item) use ($start, $end) {
-                $published = Carbon::parse($item['published_at']);
-                return $published->betweenIncluded($start, $end);
-            })->sortByDesc('published_at')->take($limit)->values()->all();
+            })->filter(function ($it) use ($start, $end) {
+                $pub = Carbon::parse($it['published_at']);
+                return $pub->betweenIncluded($start, $end);
+            })->sortByDesc('published_at')
+              ->take($limit)
+              ->values()
+              ->all();
 
+            Log::info('autosport.fetch.after', ['final_count' => count($items)]);
             return $items;
-        });
+        };
+
+        // Bypass cache pentru depanare: ?nocache=1
+        if ($nocache) {
+            return $fetchFn();
+        }
+        return Cache::remember($cacheKey, 3600, $fetchFn);
     }
 }


### PR DESCRIPTION
## Summary
- normalize Autosport RSS item parsing and include full cache key options
- allow nocache bypass, improved logging, and parameter validation for Autosport news endpoint

## Testing
- `php artisan test` *(fails: Database file at path database/database.sqlite does not exist)*
- `curl -s 'http://127.0.0.1:8000/api/news/f1?days=30&limit=20&nocache=1' | jq length`
- `curl -s 'http://127.0.0.1:8000/api/news/f1?days=30&limit=20' | jq length`


------
https://chatgpt.com/codex/tasks/task_e_68a632337d0c8323a0f63eecfaf3d133