### PR TITLE
Add race event API and SwiftUI overlay

### DIFF
--- a/API/F1_API/app/Http/Controllers/RaceEventController.php
+++ b/API/F1_API/app/Http/Controllers/RaceEventController.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\RaceEvent;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Validator;
+
+class RaceEventController extends Controller
+{
+    /**
+     * Display a listing of the events for a session.
+     */
+    public function index(Request $request, int $sessionKey)
+    {
+        $from = (int) $request->query('from_ms', 0);
+        $to = (int) $request->query('to_ms', $from + 60000);
+        $types = array_filter(explode(',', $request->query('types', 'overtake,race_control')));
+        $limit = min((int) $request->query('limit', 500), 2000);
+
+        if (!RaceEvent::where('session_key', $sessionKey)->exists()) {
+            return response()->json(['message' => 'Session not found'], 404);
+        }
+
+        $query = RaceEvent::where('session_key', $sessionKey)
+            ->whereBetween('timestamp_ms', [$from, $to])
+            ->orderBy('timestamp_ms');
+
+        if (!empty($types)) {
+            $query->whereIn('event_type', $types);
+        }
+
+        return response()->json([
+            'session_key' => $sessionKey,
+            'from_ms' => $from,
+            'to_ms' => $to,
+            'events' => $query->limit($limit)->get(),
+        ]);
+    }
+}

--- a/API/F1_API/app/Models/RaceEvent.php
+++ b/API/F1_API/app/Models/RaceEvent.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class RaceEvent extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'session_key',
+        'event_type',
+        'timestamp_ms',
+        'lap',
+        'driver_number',
+        'driver_number_overtaken',
+        'message',
+        'subtype',
+        'extra',
+    ];
+
+    protected $casts = [
+        'extra' => 'array',
+    ];
+}

--- a/API/F1_API/database/factories/RaceEventFactory.php
+++ b/API/F1_API/database/factories/RaceEventFactory.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\RaceEvent;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<RaceEvent>
+ */
+class RaceEventFactory extends Factory
+{
+    protected $model = RaceEvent::class;
+
+    public function definition(): array
+    {
+        $type = $this->faker->randomElement(['overtake', 'race_control']);
+        return [
+            'session_key' => 1,
+            'event_type' => $type,
+            'timestamp_ms' => $this->faker->numberBetween(0, 600000),
+            'lap' => $this->faker->numberBetween(1, 70),
+            'driver_number' => $this->faker->numberBetween(1, 99),
+            'driver_number_overtaken' => $type === 'overtake' ? $this->faker->numberBetween(1, 99) : null,
+            'message' => $this->faker->sentence(),
+            'subtype' => $this->faker->word(),
+            'extra' => [],
+        ];
+    }
+}

--- a/API/F1_API/database/migrations/2025_08_17_010000_create_race_events_table.php
+++ b/API/F1_API/database/migrations/2025_08_17_010000_create_race_events_table.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('race_events', function (Blueprint $table) {
+            $table->id();
+            $table->integer('session_key')->index();
+            $table->enum('event_type', ['overtake', 'race_control'])->index();
+            $table->unsignedBigInteger('timestamp_ms')->index();
+            $table->integer('lap')->nullable();
+            $table->integer('driver_number')->nullable();
+            $table->integer('driver_number_overtaken')->nullable();
+            $table->text('message')->nullable();
+            $table->string('subtype', 64)->nullable();
+            $table->json('extra')->nullable();
+            $table->timestamps();
+
+            $table->index(['session_key', 'timestamp_ms']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('race_events');
+    }
+};

--- a/API/F1_API/database/seeders/DatabaseSeeder.php
+++ b/API/F1_API/database/seeders/DatabaseSeeder.php
@@ -3,6 +3,7 @@
 namespace Database\Seeders;
 
 use App\Models\User;
+use App\Models\RaceEvent;
 // use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
 
@@ -19,5 +20,7 @@ class DatabaseSeeder extends Seeder
             'name' => 'Test User',
             'email' => 'test@example.com',
         ]);
+
+        RaceEvent::factory()->count(10)->create();
     }
 }

--- a/API/F1_API/routes/api.php
+++ b/API/F1_API/routes/api.php
@@ -11,6 +11,7 @@ use App\Http\Controllers\LiveController;
 use App\Http\Controllers\HealthController;
 use App\Http\Controllers\HistoricalController;
 use App\Http\Controllers\NewsController;
+use App\Http\Controllers\RaceEventController;
 
 Route::post('/login', [AuthController::class, 'login']);
 Route::post('/register', [AuthController::class, 'register']);
@@ -23,6 +24,7 @@ Route::middleware('auth:sanctum')->put('/password', [PasswordController::class, 
 Route::get('/drivers', [DriverController::class, 'index']);
 
 Route::get('/races', [RaceController::class, 'apiIndex'])->name('races.api');
+Route::get('/races/{sessionKey}/events', [RaceEventController::class, 'index']);
 
 Route::get('/openf1/sessions/{session_key}/drivers', [OpenF1Controller::class, 'sessionDrivers']);
 Route::get('/openf1/sessions/{session_key}/laps', [OpenF1Controller::class, 'sessionLaps']);

--- a/F1App/F1App/EventToastView.swift
+++ b/F1App/F1App/EventToastView.swift
@@ -1,0 +1,39 @@
+import SwiftUI
+
+struct EventToastView: View {
+    let event: RaceEvent
+
+    var iconName: String {
+        switch event.eventType {
+        case .overtake: return "arrow.up.arrow.down.circle"
+        case .race_control: return "exclamationmark.triangle"
+        }
+    }
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 4) {
+            Image(systemName: iconName)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(text)
+                    .font(.caption)
+                    .lineLimit(2)
+            }
+        }
+        .padding(8)
+        .background(.ultraThinMaterial)
+        .clipShape(RoundedRectangle(cornerRadius: 8))
+        .shadow(radius: 2)
+    }
+
+    private var text: String {
+        switch event.eventType {
+        case .overtake:
+            if let d1 = event.driverNumber, let d2 = event.driverNumberOvertaken, let lap = event.lap {
+                return "#\(d1) a depășit #\(d2) — Lap \(lap)"
+            }
+            return event.message ?? "Overtake"
+        case .race_control:
+            return event.message ?? "Race Control"
+        }
+    }
+}

--- a/F1App/F1App/EventToastsOverlay.swift
+++ b/F1App/F1App/EventToastsOverlay.swift
@@ -1,0 +1,17 @@
+import SwiftUI
+
+struct EventToastsOverlay: View {
+    let toasts: [ToastEvent]
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            ForEach(toasts.prefix(3)) { toast in
+                EventToastView(event: toast.event)
+                    .transition(.move(edge: .top).combined(with: .opacity))
+            }
+        }
+        .padding()
+        .frame(maxWidth: .infinity, alignment: .topLeading)
+        .allowsHitTesting(false)
+    }
+}

--- a/F1App/F1App/HistoricEventsViewModel.swift
+++ b/F1App/F1App/HistoricEventsViewModel.swift
@@ -1,0 +1,69 @@
+import Foundation
+import Combine
+
+class HistoricEventsViewModel: ObservableObject {
+    @Published var activeToasts: [ToastEvent] = []
+
+    private var sessionKey: Int
+    private let service: RaceEventService
+    private var preloaded: [ClosedRange<Int64>: [RaceEvent]] = [:]
+    private var shownEventIds: Set<Int64> = []
+
+    init(sessionKey: Int, service: RaceEventService = RaceEventService()) {
+        self.sessionKey = sessionKey
+        self.service = service
+    }
+
+    func setSessionKey(_ newKey: Int) {
+        sessionKey = newKey
+        preloaded.removeAll()
+        shownEventIds.removeAll()
+        activeToasts.removeAll()
+    }
+
+    func update(nowMs: Int64) {
+        Task {
+            await preloadIfNeeded(nowMs: nowMs)
+            await MainActor.run {
+                self.removeExpired(nowMs: nowMs)
+                self.addNewToasts(nowMs: nowMs)
+            }
+        }
+    }
+
+    private func preloadIfNeeded(nowMs: Int64) async {
+        let windowStart = nowMs - 60_000
+        let windowEnd = nowMs + 60_000
+        let range = windowStart...windowEnd
+        guard preloaded.keys.first(where: { $0.contains(nowMs) }) == nil else { return }
+        do {
+            let events = try await service.fetchEvents(sessionKey: sessionKey, fromMs: windowStart, toMs: windowEnd, types: [.overtake, .race_control])
+            preloaded[range] = events
+        } catch {
+            // ignore errors for now
+        }
+    }
+
+    private func events(in range: ClosedRange<Int64>) -> [RaceEvent] {
+        for (window, evts) in preloaded where window.overlaps(range) {
+            return evts.filter { range.contains($0.timestampMs) }
+        }
+        return []
+    }
+
+    private func removeExpired(nowMs: Int64) {
+        activeToasts.removeAll { $0.expiresAtMs <= nowMs }
+    }
+
+    private func addNewToasts(nowMs: Int64) {
+        let window = (nowMs-20_000)...nowMs
+        let candidates = events(in: window).filter { e in
+            nowMs >= e.timestampMs && nowMs < e.timestampMs + 20_000 && !shownEventIds.contains(e.id)
+        }
+        for event in candidates {
+            if activeToasts.count >= 3 { break }
+            shownEventIds.insert(event.id)
+            activeToasts.append(ToastEvent(id: event.id, event: event, expiresAtMs: event.timestampMs + 20_000))
+        }
+    }
+}

--- a/F1App/F1App/HistoricalRaceView.swift
+++ b/F1App/F1App/HistoricalRaceView.swift
@@ -10,9 +10,13 @@ struct HistoricalRaceView: View {
     }
 
     @State private var selectedDriver: DriverSelection?
+    @StateObject private var eventsVM = HistoricEventsViewModel(sessionKey: 0)
+    @State private var playbackTimeMs: Int64 = 0
+    private let timer = Timer.publish(every: 0.25, on: .main, in: .common).autoconnect()
 
     var body: some View {
-        VStack {
+        ZStack(alignment: .topLeading) {
+            VStack {
             HStack {
                 TextField("Anul", text: $viewModel.year)
                     .keyboardType(.numberPad)
@@ -142,18 +146,26 @@ struct HistoricalRaceView: View {
             }
             Spacer()
         }
-        .sheet(isPresented: $showDebug) {
-            VStack {
-                if let sum = viewModel.diagnosisSummary {
-                    Text(sum).font(.headline).padding()
-                }
-                DebugLogView(logger: viewModel.logger)
+        EventToastsOverlay(toasts: eventsVM.activeToasts)
+    }
+    .onReceive(timer) { _ in
+        if viewModel.isRunning { playbackTimeMs += 250 }
+        eventsVM.update(nowMs: playbackTimeMs)
+    }
+    .onChange(of: viewModel.sessionKey) { key in
+        if let k = key { eventsVM.setSessionKey(k) }
+    }
+    .sheet(isPresented: $showDebug) {
+        VStack {
+            if let sum = viewModel.diagnosisSummary {
+                Text(sum).font(.headline).padding()
             }
+            DebugLogView(logger: viewModel.logger)
         }
-        .sheet(item: $selectedDriver) { selection in
-            DriverDetailView(driver: selection.driver,
-                             sessionKey: viewModel.sessionKey,
-                             raceViewModel: viewModel)
-        }
+    }
+    .sheet(item: $selectedDriver) { selection in
+        DriverDetailView(driver: selection.driver,
+                         sessionKey: viewModel.sessionKey,
+                         raceViewModel: viewModel)
     }
 }

--- a/F1App/F1App/Models/RaceEvent.swift
+++ b/F1App/F1App/Models/RaceEvent.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+struct RaceEvent: Identifiable, Decodable, Hashable {
+    let id: Int64
+    let eventType: EventType
+    let timestampMs: Int64
+    let lap: Int?
+    let driverNumber: Int?
+    let driverNumberOvertaken: Int?
+    let message: String?
+    let subtype: String?
+    let extra: [String: String]?
+
+    enum EventType: String, Decodable {
+        case overtake
+        case race_control
+    }
+}
+
+struct ToastEvent: Identifiable, Hashable {
+    let id: Int64
+    let event: RaceEvent
+    let expiresAtMs: Int64
+}

--- a/F1App/F1App/Services/RaceEventService.swift
+++ b/F1App/F1App/Services/RaceEventService.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+class RaceEventService {
+    private let session: URLSession
+    private var cache: [ClosedRange<Int64>: [RaceEvent]] = [:]
+
+    init(session: URLSession = .shared) {
+        self.session = session
+    }
+
+    func fetchEvents(sessionKey: Int, fromMs: Int64, toMs: Int64, types: [RaceEvent.EventType]) async throws -> [RaceEvent] {
+        let range = fromMs...toMs
+        if let cached = cache[range] {
+            return cached
+        }
+
+        var comps = URLComponents(string: "\(APIConfig.baseURL)/api/races/\(sessionKey)/events")!
+        comps.queryItems = [
+            URLQueryItem(name: "from_ms", value: String(fromMs)),
+            URLQueryItem(name: "to_ms", value: String(toMs)),
+            URLQueryItem(name: "types", value: types.map { $0.rawValue }.joined(separator: ","))
+        ]
+        let (data, _) = try await session.data(from: comps.url!)
+        let decoder = JSONDecoder()
+        let wrapper = try decoder.decode(ResponseWrapper.self, from: data)
+        cache[range] = wrapper.events
+        return wrapper.events
+    }
+
+    private struct ResponseWrapper: Decodable {
+        let events: [RaceEvent]
+    }
+}


### PR DESCRIPTION
## Summary
- add race_events table and seeder
- expose REST endpoint for session events
- display race event toasts in HistoricRaceView

## Testing
- `php artisan test` *(fails: Database file at path [...] does not exist)*
- `xcodebuild -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a70cb748d88323b60061d52e721ad0