### PR TITLE
Show race messages sequentially

### DIFF
--- a/F1App/F1App/HistoricalRaceView.swift
+++ b/F1App/F1App/HistoricalRaceView.swift
@@ -91,25 +91,11 @@ struct HistoricalRaceView: View {
                         .padding(.bottom)
                 }
 
-                if let overtake = viewModel.overtakeMessage {
-                    Text(overtake)
+                if let message = viewModel.currentEventMessage {
+                    Text(message)
                         .padding(8)
                         .background(Color.yellow.opacity(0.2))
                         .cornerRadius(8)
-                }
-
-                if !viewModel.raceControlMessages.isEmpty {
-                    List(viewModel.raceControlMessages) { msg in
-                        HStack(alignment: .top) {
-                            if let lap = msg.lapNumber {
-                                Text("Tur \(lap)")
-                                    .bold()
-                            }
-                            Text(msg.message ?? "")
-                                .font(.caption)
-                        }
-                    }
-                    .frame(maxHeight: 200)
                 }
 
                 if viewModel.maxSteps > 1 {


### PR DESCRIPTION
## Summary
- Queue and display race control and overtake messages sequentially during historical playback
- Expose current event message to UI with 30s display duration

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68a710f135bc8323b98515325fc9d8c7