### PR TITLE
Enable snake_case decoding for race events and improve date parsing

### DIFF
--- a/F1App/F1App/HistoricalRaceViewModel.swift
+++ b/F1App/F1App/HistoricalRaceViewModel.swift
@@ -232,7 +232,9 @@ class HistoricalRaceViewModel: ObservableObject {
             }
             guard let data = data else { return }
             do {
-                let response = try JSONDecoder().decode(EventsResponse.self, from: data)
+                let decoder = JSONDecoder()
+                decoder.keyDecodingStrategy = .convertFromSnakeCase
+                let response = try decoder.decode(EventsResponse.self, from: data)
                 let sorted: [RaceEventDTO]
                 if let start = self.sessionStartDate {
                     sorted = response.data.sorted {
@@ -266,7 +268,9 @@ class HistoricalRaceViewModel: ObservableObject {
             }
             guard let data = data else { return }
             do {
-                let response = try JSONDecoder().decode(EventsResponse.self, from: data)
+                let decoder = JSONDecoder()
+                decoder.keyDecodingStrategy = .convertFromSnakeCase
+                let response = try decoder.decode(EventsResponse.self, from: data)
                 let sorted: [RaceEventDTO]
                 if let start = self.sessionStartDate {
                     sorted = response.data.sorted {

--- a/F1App/F1App/Models/RaceEventDTO.swift
+++ b/F1App/F1App/Models/RaceEventDTO.swift
@@ -46,9 +46,12 @@ func eventTimeMs(_ dto: RaceEventDTO, sessionStart: Date) -> Int64? {
         let f = DateFormatter()
         f.locale = Locale(identifier: "en_US_POSIX")
         f.timeZone = TimeZone(secondsFromGMT: 0)
-        f.dateFormat = "yyyy-MM-dd HH:mm:ss.SSSSSS"
-        if let d = f.date(from: raw) {
-            return Int64(d.timeIntervalSince(sessionStart) * 1000)
+        let formats = ["yyyy-MM-dd HH:mm:ss.SSSSSS", "yyyy-MM-dd HH:mm:ss"]
+        for format in formats {
+            f.dateFormat = format
+            if let d = f.date(from: raw) {
+                return Int64(d.timeIntervalSince(sessionStart) * 1000)
+            }
         }
     }
     return nil


### PR DESCRIPTION
## Summary
- Decode race control and overtake event payloads with `convertFromSnakeCase` to map snake_case keys.
- Support fallback race event timestamps without microseconds.

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild -scheme F1App -project F1App/F1App.xcodeproj -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 14' test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a7a08ccdbc8323914a20ace6fc3d2c