### PR TITLE
Fix playback toast timing and clamp negative event times

### DIFF
--- a/API/F1_API/app/Http/Controllers/OvertakesController.php
+++ b/API/F1_API/app/Http/Controllers/OvertakesController.php
@@ -28,7 +28,7 @@ class OvertakesController extends Controller
                 "DATE_FORMAT(CONVERT_TZ(o.`date`, '+00:00', '+00:00'), '%Y-%m-%dT%H:%i:%s.%fZ') as date_iso"
             )
             ->selectRaw(
-                "TIMESTAMPDIFF(MICROSECOND, s.`date_start`, o.`date`) / 1000 as timestamp_ms"
+                "GREATEST(0, TIMESTAMPDIFF(MICROSECOND, s.`date_start`, o.`date`) / 1000) as timestamp_ms"
             );
 
         if ($sessionKey = $request->query('session_key')) {

--- a/API/F1_API/app/Http/Controllers/RaceControlController.php
+++ b/API/F1_API/app/Http/Controllers/RaceControlController.php
@@ -33,7 +33,7 @@ class RaceControlController extends Controller
                 "DATE_FORMAT(CONVERT_TZ(rc.`date`, '+00:00', '+00:00'), '%Y-%m-%dT%H:%i:%s.%fZ') as date_iso"
             )
             ->selectRaw(
-                "TIMESTAMPDIFF(MICROSECOND, s.`date_start`, rc.`date`) / 1000 as timestamp_ms"
+                "GREATEST(0, TIMESTAMPDIFF(MICROSECOND, s.`date_start`, rc.`date`) / 1000) as timestamp_ms"
             );
 
         if ($sessionKey = $request->query('session_key')) {

--- a/F1App/F1App/Models/RaceEventDTO.swift
+++ b/F1App/F1App/Models/RaceEventDTO.swift
@@ -56,3 +56,15 @@ func eventTimeMs(_ dto: RaceEventDTO, sessionStart: Date) -> Int64? {
     }
     return nil
 }
+
+extension RaceEventDTO {
+    var renderedText: String {
+        if let dn = driverNumber, let dover = driverNumberOvertaken {
+            let lapText = lapNumber.map { " — Lap \($0)" } ?? ""
+            return "Overtake: #\(dn) a depășit #\(dover)\(lapText)"
+        }
+        if let msg = message, !msg.isEmpty { return msg }
+        if let cat = category { return "Race Control: \(cat)" }
+        return "Eveniment cursă"
+    }
+}


### PR DESCRIPTION
## Summary
- Clamp negative timestamps in race control and overtake APIs
- Sort events with a session-start fallback and postpone fetching until start is known
- Add playback toast engine that surfaces race-control and overtake messages for 20s

## Testing
- `php -l API/F1_API/app/Http/Controllers/RaceControlController.php`
- `php -l API/F1_API/app/Http/Controllers/OvertakesController.php`
- `swiftc -typecheck F1App/F1App/Models/RaceEventDTO.swift`
- `swiftc -typecheck F1App/F1App/HistoricalRaceViewModel.swift` *(fails: no such module 'SwiftUI')*


------
https://chatgpt.com/codex/tasks/task_e_68a7a62977348323b1ab8979c4b103c4