### PR TITLE
Enable smooth interpolation for historical race playback

### DIFF
--- a/F1App/F1App/HistoricalRaceView.swift
+++ b/F1App/F1App/HistoricalRaceView.swift
@@ -33,9 +33,13 @@ struct HistoricalRaceView: View {
                 GeometryReader { geo in
                     let bounds = CGRect(origin: .zero, size: geo.size)
                     let outOfBounds = viewModel.drivers.contains { driver in
-                        if let loc = viewModel.currentPosition[driver.driver_number] {
-                            let p = viewModel.point(for: loc, in: geo.size)
-                            return !bounds.contains(p)
+                        if viewModel.historicalSmoothEnabled,
+                           let p = viewModel.interpolatedPosition[driver.driver_number] {
+                            let pt = viewModel.point(forInterpolated: p, in: geo.size)
+                            return !bounds.contains(pt)
+                        } else if let loc = viewModel.currentPosition[driver.driver_number] {
+                            let pt = viewModel.point(for: loc, in: geo.size)
+                            return !bounds.contains(pt)
                         }
                         return false
                     }
@@ -55,7 +59,22 @@ struct HistoricalRaceView: View {
 
                         if !viewModel.currentPosition.isEmpty {
                             ForEach(viewModel.drivers) { driver in
-                                if let loc = viewModel.currentPosition[driver.driver_number] {
+                                if viewModel.historicalSmoothEnabled,
+                                   let p = viewModel.interpolatedPosition[driver.driver_number] {
+                                    let point = viewModel.point(forInterpolated: p, in: geo.size)
+                                    if bounds.contains(point) {
+                                        Circle()
+                                            .fill(Color(hex: driver.team_color ?? "FF0000"))
+                                            .frame(width: 8, height: 8)
+                                            .position(point)
+                                            .onTapGesture {
+                                                selectedDriver = DriverSelection(driver: driver)
+                                            }
+                                        Text(driver.initials)
+                                            .font(.caption2)
+                                            .position(x: point.x, y: point.y - 10)
+                                    }
+                                } else if let loc = viewModel.currentPosition[driver.driver_number] {
                                     let point = viewModel.point(for: loc, in: geo.size)
                                     if bounds.contains(point) {
                                         Circle()
@@ -125,6 +144,10 @@ struct HistoricalRaceView: View {
                     }
                 }
                 .padding(.bottom)
+                if viewModel.debugEnabled {
+                    Toggle("Smooth (historical)", isOn: $viewModel.historicalSmoothEnabled)
+                        .padding(.horizontal)
+                }
             }
             Spacer()
         }

--- a/F1App/F1App/HistoricalRaceViewModel.swift
+++ b/F1App/F1App/HistoricalRaceViewModel.swift
@@ -1,6 +1,7 @@
 import Foundation
 import SwiftUI
 import CoreLocation
+import QuartzCore
 
 struct DriverInfo: Identifiable, Decodable, Hashable {
     let driver_number: Int
@@ -46,6 +47,9 @@ class HistoricalRaceViewModel: ObservableObject {
     @Published var debugEnabled = true
     @Published var diagnosisSummary: String?
     @Published var currentEventMessage: String?
+    @Published var historicalSmoothEnabled: Bool = true
+    @Published var interpolatedPosition: [Int: (x: Double, y: Double)] = [:]
+    @Published var playbackNowMs: Int64 = 0
     private var allRaceControlMessages: [RaceEventDTO] = []
     private var allOvertakes: [RaceEventDTO] = []
     private var nextRaceControlIndex = 0
@@ -62,6 +66,10 @@ class HistoricalRaceViewModel: ObservableObject {
     private var timer: Timer?
     private let speedOptions: [Double] = [1, 2, 5]
     private var speedIndex = 0
+    private let locService = HistoricalLocationService()
+    private var sampleBuffers: [Int: [TimedPoint]] = [:]
+    private var displayLink: CADisplayLink?
+    private var lastDisplayTimestamp: TimeInterval?
     private let dateFormatter: ISO8601DateFormatter = {
         let formatter = ISO8601DateFormatter()
         formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
@@ -79,6 +87,10 @@ class HistoricalRaceViewModel: ObservableObject {
     private var locationBounds: CGRect = CGRect(x: 0, y: 0, width: 1, height: 1)
     private var locationFetchCount = 0
 
+    init() {
+        locService.logger = logger
+    }
+
     private func log(_ title: String, _ detail: String = "") {
         guard debugEnabled else { return }
         logger.log(title, detail)
@@ -95,6 +107,9 @@ class HistoricalRaceViewModel: ObservableObject {
         stepIndex = 0
         positions.removeAll()
         currentPosition.removeAll()
+        interpolatedPosition.removeAll()
+        sampleBuffers.removeAll()
+        playbackNowMs = 0
         currentEventMessage = nil
         allRaceControlMessages.removeAll()
         allOvertakes.removeAll()
@@ -420,17 +435,32 @@ class HistoricalRaceViewModel: ObservableObject {
         return CGPoint(x: nx * size.width, y: ny * size.height)
     }
 
+    public func point(forInterpolated p: (x: Double, y: Double), in size: CGSize) -> CGPoint {
+        guard locationBounds.width != 0, locationBounds.height != 0 else { return .zero }
+        let rawX = (p.x - locationBounds.minX) / locationBounds.width
+        let rawY = 1 - (p.y - locationBounds.minY) / locationBounds.height
+        let nx = max(0, min(rawX, 1))
+        let ny = max(0, min(rawY, 1))
+        return CGPoint(x: nx * size.width, y: ny * size.height)
+    }
+
     func start() {
         guard !isRunning else { pause(); return }
         guard maxSteps > 0 else { return }
         isRunning = true
         scheduleNextStep()
+        if historicalSmoothEnabled, let start = sessionStartDate {
+            let nowAbs = start.addingTimeInterval(TimeInterval(playbackNowMs) / 1000)
+            fetchSamplesIfNeeded(nowAbs: nowAbs)
+            startDisplayLink()
+        }
     }
 
     func pause() {
         isRunning = false
         timer?.invalidate()
         timer = nil
+        stopDisplayLink()
     }
 
     func cycleSpeed() {
@@ -454,6 +484,7 @@ class HistoricalRaceViewModel: ObservableObject {
         }
         if let start = sessionStartDate, let current = currentRaceDate() {
             let nowMs = Int64(current.timeIntervalSince(start) * 1000)
+            playbackNowMs = nowMs
             onPlaybackTick(nowMs: nowMs)
         }
     }
@@ -465,6 +496,98 @@ class HistoricalRaceViewModel: ObservableObject {
             }
         }
         return nil
+    }
+
+    private func startDisplayLink() {
+        stopDisplayLink()
+        displayLink = CADisplayLink(target: self, selector: #selector(displayLinkTick(_:)))
+        displayLink?.preferredFramesPerSecond = 60
+        displayLink?.add(to: .main, forMode: .common)
+        lastDisplayTimestamp = nil
+    }
+
+    private func stopDisplayLink() {
+        displayLink?.invalidate()
+        displayLink = nil
+        lastDisplayTimestamp = nil
+    }
+
+    @objc private func displayLinkTick(_ link: CADisplayLink) {
+        guard historicalSmoothEnabled, let start = sessionStartDate else { return }
+        if lastDisplayTimestamp == nil { lastDisplayTimestamp = link.timestamp }
+        let delta = (link.timestamp - (lastDisplayTimestamp ?? link.timestamp)) * playbackSpeed
+        playbackNowMs += Int64(delta * 1000)
+        lastDisplayTimestamp = link.timestamp
+        let nowAbs = start.addingTimeInterval(TimeInterval(playbackNowMs) / 1000)
+        updateInterpolatedPositions(nowAbs: nowAbs)
+        fetchSamplesIfNeeded(nowAbs: nowAbs)
+    }
+
+    private func updateInterpolatedPositions(nowAbs: Date) {
+        guard historicalSmoothEnabled, sessionStartDate != nil else { return }
+        let t = nowAbs.timeIntervalSince1970
+        for driver in drivers {
+            if let samples = sampleBuffers[driver.driver_number], !samples.isEmpty,
+               let p = PositionInterpolator.interpolate(at: t, samples: samples) {
+                interpolatedPosition[driver.driver_number] = p
+            }
+        }
+    }
+
+    private func fetchSamplesIfNeeded(nowAbs: Date) {
+        guard historicalSmoothEnabled, let sk = sessionKey else { return }
+        let t = nowAbs.timeIntervalSince1970
+        for driver in drivers {
+            var buffer = sampleBuffers[driver.driver_number] ?? []
+            let needFetch: Bool
+            if buffer.isEmpty {
+                needFetch = true
+            } else {
+                let windowAhead: TimeInterval = 60
+                let windowBehind: TimeInterval = 30
+                needFetch = t > (buffer.last!.t - windowAhead / 2) || t < (buffer.first!.t + windowBehind / 2)
+            }
+            if needFetch {
+                fetchSamples(for: driver.driver_number, around: nowAbs, sessionKey: sk)
+            }
+        }
+    }
+
+    private func fetchSamples(for driverNumber: Int, around nowAbs: Date, sessionKey: Int) {
+        let windowAhead: TimeInterval = 60
+        let windowBehind: TimeInterval = 30
+        let gt = nowAbs.addingTimeInterval(-windowBehind).iso8601FracZ()
+        let lt = nowAbs.addingTimeInterval(windowAhead).iso8601FracZ()
+        locService.fetchChunk(sessionKey: sessionKey, driverNumber: driverNumber, dateGtISO: gt, dateLtISO: lt) { result in
+            switch result {
+            case .success(let arr):
+                var points: [TimedPoint] = []
+                for dto in arr {
+                    var d: Date?
+                    if let iso = dto.dateIso { d = self.dateFormatter.date(from: iso) }
+                    if d == nil, let ds = dto.date { d = self.backendFormatter.date(from: ds) }
+                    if let d = d {
+                        points.append(TimedPoint(t: d.timeIntervalSince1970,
+                                                  x: Double(dto.x),
+                                                  y: Double(dto.y)))
+                    }
+                }
+                DispatchQueue.main.async {
+                    var buffer = self.sampleBuffers[driverNumber] ?? []
+                    buffer.append(contentsOf: points)
+                    buffer.sort { $0.t < $1.t }
+                    var unique: [TimedPoint] = []
+                    var lastT: TimeInterval?
+                    for p in buffer {
+                        if p.t != lastT { unique.append(p); lastT = p.t }
+                    }
+                    self.sampleBuffers[driverNumber] = unique
+                    self.updateInterpolatedPositions(nowAbs: nowAbs)
+                }
+            case .failure(let err):
+                self.log("chunk error", err.localizedDescription)
+            }
+        }
     }
 
     func onPlaybackTick(nowMs: Int64) {

--- a/F1App/F1App/Services/HistoricalLocationService.swift
+++ b/F1App/F1App/Services/HistoricalLocationService.swift
@@ -1,0 +1,62 @@
+import Foundation
+
+struct DriverLocationDTO: Decodable {
+    let driverNumber: Int
+    let date: String?
+    let dateIso: String?
+    let x: Int
+    let y: Int
+    let z: Int?
+
+    private enum CodingKeys: String, CodingKey {
+        case driverNumber = "driver_number"
+        case date
+        case dateIso = "date_iso"
+        case x
+        case y
+        case z
+    }
+}
+
+final class HistoricalLocationService {
+    var logger: DebugLogger?
+
+    func fetchChunk(sessionKey: Int,
+                    driverNumber: Int,
+                    dateGtISO: String,
+                    dateLtISO: String,
+                    limit: Int = 1000,
+                    offset: Int = 0,
+                    completion: @escaping (Result<[DriverLocationDTO], Error>) -> Void) {
+        var comps = URLComponents(string: "\(APIConfig.baseURL)/api/openf1/location")!
+        comps.queryItems = [
+            URLQueryItem(name: "session_key", value: String(sessionKey)),
+            URLQueryItem(name: "driver_number", value: String(driverNumber)),
+            URLQueryItem(name: "date__gt", value: dateGtISO),
+            URLQueryItem(name: "date__lt", value: dateLtISO),
+            URLQueryItem(name: "order_by", value: "date"),
+            URLQueryItem(name: "limit", value: String(limit)),
+            URLQueryItem(name: "offset", value: String(offset))
+        ]
+        let url = comps.url!
+        URLSession.shared.dataTask(with: url) { data, resp, error in
+            self.logger?.log("GET /openf1/location", "url=\(url)\nerr=\(String(describing: error)) status=\((resp as? HTTPURLResponse)?.statusCode ?? -1)")
+            if let error = error {
+                completion(.failure(error))
+                return
+            }
+            guard let data = data else {
+                completion(.success([]))
+                return
+            }
+            do {
+                struct Response: Decodable { let data: [DriverLocationDTO] }
+                let decoded = try JSONDecoder().decode(Response.self, from: data)
+                completion(.success(decoded.data))
+            } catch {
+                completion(.failure(error))
+            }
+        }.resume()
+    }
+}
+

--- a/F1App/F1App/Utils/ISO8601+Helpers.swift
+++ b/F1App/F1App/Utils/ISO8601+Helpers.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+extension Date {
+    func iso8601FracZ() -> String {
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        f.timeZone = TimeZone(secondsFromGMT: 0)
+        return f.string(from: self)
+    }
+}
+

--- a/F1App/F1App/Utils/PositionInterpolator.swift
+++ b/F1App/F1App/Utils/PositionInterpolator.swift
@@ -1,0 +1,48 @@
+import Foundation
+
+struct TimedPoint {
+    let t: TimeInterval
+    let x: Double
+    let y: Double
+}
+
+enum InterpMode {
+    case linear
+}
+
+enum PositionInterpolator {
+    static func interpolate(at t: TimeInterval,
+                            samples: [TimedPoint],
+                            mode: InterpMode = .linear) -> (x: Double, y: Double)? {
+        guard !samples.isEmpty else { return nil }
+        if t <= samples.first!.t {
+            return (samples.first!.x, samples.first!.y)
+        }
+        if t >= samples.last!.t {
+            return (samples.last!.x, samples.last!.y)
+        }
+        // binary search to find pair t0<=t<=t1
+        var low = 0
+        var high = samples.count - 1
+        while low <= high {
+            let mid = (low + high) / 2
+            let tm = samples[mid].t
+            if tm == t {
+                return (samples[mid].x, samples[mid].y)
+            } else if tm < t {
+                low = mid + 1
+            } else {
+                high = mid - 1
+            }
+        }
+        let i1 = max(1, low)
+        let i0 = i1 - 1
+        let p0 = samples[i0]
+        let p1 = samples[i1]
+        let ratio = (t - p0.t) / (p1.t - p0.t)
+        let x = p0.x + (p1.x - p0.x) * ratio
+        let y = p0.y + (p1.y - p0.y) * ratio
+        return (x, y)
+    }
+}
+


### PR DESCRIPTION
## Summary
- Add `HistoricalLocationService` to fetch driver positions from `/openf1/location`
- Implement `PositionInterpolator` and ISO8601 helpers for smooth coordinate interpolation
- Extend `HistoricalRaceViewModel` and `HistoricalRaceView` with optional smooth playback and debug toggle

## Testing
- `swift --version`
- `swift build` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*

------
https://chatgpt.com/codex/tasks/task_e_68a7abce5f4c8323b9011def10249f8d