### PR TITLE
Smooth linear animation for historical race markers

### DIFF
--- a/F1App/F1App/HistoricalRaceView.swift
+++ b/F1App/F1App/HistoricalRaceView.swift
@@ -78,7 +78,7 @@ struct HistoricalRaceView: View {
                             }
                         }
                     }
-                    .animation(.easeInOut(duration: viewModel.currentStepDuration), value: viewModel.stepIndex)
+                    .animation(.linear(duration: viewModel.currentStepDuration), value: viewModel.stepIndex)
                 }
                 .frame(height: 300)
                 .background(Color.gray.opacity(0.1))

--- a/F1App/F1App/HistoricalRaceViewModel.swift
+++ b/F1App/F1App/HistoricalRaceViewModel.swift
@@ -518,7 +518,7 @@ class HistoricalRaceViewModel: ObservableObject {
         let scaled = interval / playbackSpeed
         currentStepDuration = scaled
         let newTimer = Timer(timeInterval: scaled, repeats: false) { _ in
-            withAnimation(.easeInOut(duration: self.currentStepDuration)) {
+            withAnimation(.linear(duration: self.currentStepDuration)) {
                 self.stepIndex += 1
                 self.updatePositions()
             }


### PR DESCRIPTION
## Summary
- Use linear animation for historical race driver markers
- Match historical race playback smoothing to circuit section

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild test -project F1App/F1App.xcodeproj -scheme F1App -destination 'platform=iOS Simulator,name=iPhone 14' >/tmp/xcode.log && tail -n 20 /tmp/xcode.log` *(fails: command not found: xcodebuild)*

------
https://chatgpt.com/codex/tasks/task_e_68a7af655c04832380e1d51e5529a045