### PR TITLE
Add animated vector F1 splash screen

### DIFF
--- a/F1App/F1App.xcodeproj/project.pbxproj
+++ b/F1App/F1App.xcodeproj/project.pbxproj
@@ -401,7 +401,8 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
-				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = NO;
+                                INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -430,7 +431,8 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
-				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = NO;
+                                INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				LD_RUNPATH_SEARCH_PATHS = (

--- a/F1App/F1App/Base.lproj/LaunchScreen.storyboard
+++ b/F1App/F1App/Base.lproj/LaunchScreen.storyboard
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21225.4" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" colorMatched="YES">
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="Fs0-0j-SEF">
+            <objects>
+                <viewController id="VC1" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="v1">
+                        <rect key="frame" x="0" y="0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" red="0" green="0" blue="0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="FR1" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+        </scene>
+    </scenes>
+</document>

--- a/F1App/F1App/F1AppApp.swift
+++ b/F1App/F1App/F1AppApp.swift
@@ -9,9 +9,21 @@ import SwiftUI
 
 @main
 struct F1AppApp: App {
+    @State private var showSplash = true
+
     var body: some Scene {
         WindowGroup {
-            ContentView()
+            ZStack {
+                ContentView()
+                    .opacity(showSplash ? 0 : 1)
+
+                if showSplash {
+                    VectorSplashView {
+                        showSplash = false
+                    }
+                    .transition(.opacity)
+                }
+            }
         }
     }
 }

--- a/F1App/F1App/Views/Splash/F1MarkShape.swift
+++ b/F1App/F1App/Views/Splash/F1MarkShape.swift
@@ -1,0 +1,44 @@
+import SwiftUI
+
+/// Marcă stilizată F1 (nu logo oficial), desenată din poligoane.
+/// Coordonatele sunt normalizate după o bază 260x54 și scalate la rect.
+struct F1MarkShape: Shape {
+    func path(in rect: CGRect) -> Path {
+        let sx = rect.width / 260.0
+        let sy = rect.height / 54.0
+
+        func P(_ x: CGFloat, _ y: CGFloat) -> CGPoint {
+            CGPoint(x: rect.minX + x * sx, y: rect.minY + y * sy)
+        }
+
+        var path = Path()
+
+        // „F” stilizat (stânga)
+        path.move(to: P(0, 0))
+        path.addLine(to: P(140, 0))
+        path.addLine(to: P(140, 18))
+        path.addLine(to: P(40, 18))
+        path.addLine(to: P(40, 36))
+        path.addLine(to: P(110, 36))
+        path.addLine(to: P(110, 54))
+        path.addLine(to: P(0, 54))
+        path.closeSubpath()
+
+        // „Aripa” / speed block (dreapta)
+        path.move(to: P(160, 0))
+        path.addLine(to: P(260, 0))
+        path.addLine(to: P(210, 54))
+        path.addLine(to: P(110, 54))
+        path.closeSubpath()
+
+        return path
+    }
+}
+
+/// Linii de viteză simple (pentru efect vizual)
+struct SpeedLineShape: Shape {
+    func path(in rect: CGRect) -> Path {
+        var p = Path(roundedRect: rect, cornerRadius: rect.height/2)
+        return p
+    }
+}

--- a/F1App/F1App/Views/Splash/F1VectorLogo.swift
+++ b/F1App/F1App/Views/Splash/F1VectorLogo.swift
@@ -1,0 +1,12 @@
+import SwiftUI
+
+struct F1VectorLogo: View {
+    var body: some View {
+        F1MarkShape()
+            .fill(Color.red)
+            .drawingGroup() // rasterizare pt. anti-alias
+            .aspectRatio(260/54.0, contentMode: .fit)
+            .frame(width: 240) // se poate ajusta
+            .accessibilityLabel("F1 style mark")
+    }
+}

--- a/F1App/F1App/Views/Splash/VectorSplashView.swift
+++ b/F1App/F1App/Views/Splash/VectorSplashView.swift
@@ -1,0 +1,45 @@
+import SwiftUI
+
+struct VectorSplashView: View {
+    var onFinish: () -> Void
+    @State private var appear = false
+    @State private var showLines = false
+
+    var body: some View {
+        ZStack {
+            Color.black.ignoresSafeArea()
+
+            // Logo vectorial (fără imagini)
+            F1VectorLogo()
+                .scaleEffect(appear ? 1.0 : 0.85)
+                .opacity(appear ? 1.0 : 0.0)
+                .animation(.easeOut(duration: 0.45), value: appear)
+
+            if showLines {
+                // 3 linii care „vin din stânga”
+                VStack(spacing: 8) {
+                    speedLine(width: 160).offset(x: appear ? 0 : -240)
+                    speedLine(width: 200).offset(x: appear ? 0 : -280)
+                    speedLine(width: 240).offset(x: appear ? 0 : -320)
+                }
+                .frame(width: 260, height: 80, alignment: .trailing)
+                .offset(y: 70)
+                .animation(.easeOut(duration: 0.6), value: appear)
+            }
+        }
+        .onAppear {
+            showLines = true
+            appear = true
+            // Finalizează splash-ul după ~1.2s
+            DispatchQueue.main.asyncAfter(deadline: .now() + 1.2) {
+                withAnimation(.easeInOut(duration: 0.25)) { onFinish() }
+            }
+        }
+    }
+
+    private func speedLine(width: CGFloat) -> some View {
+        SpeedLineShape()
+            .fill(Color.red.opacity(0.85))
+            .frame(width: width, height: 8)
+    }
+}


### PR DESCRIPTION
## Summary
- Add LaunchScreen.storyboard with black background
- Draw F1-style vector logo and speed lines using SwiftUI shapes
- Show animated splash screen before main content

## Testing
- `swift --version`
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68a7b745bc2c8323ab39148831a8924c