### PR TITLE
Add gradual fade out to splash logo

### DIFF
--- a/F1App/F1App/Views/Splash/VectorSplashView.swift
+++ b/F1App/F1App/Views/Splash/VectorSplashView.swift
@@ -12,15 +12,16 @@ struct VectorSplashView: View {
             F1VectorLogo()
                 .scaleEffect(appear ? 1.0 : 0.85)
                 .opacity(appear ? 1.0 : 0.0)
-                .animation(.easeOut(duration: 0.45), value: appear)
+                .animation(.easeInOut(duration: 0.45), value: appear)
         }
         .onAppear {
             appear = true
-            // Finalizează splash-ul după ~1.2s
             DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
-                withAnimation(.easeInOut(duration: 0.25)) { onFinish() }
+                appear = false
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.45) {
+                    onFinish()
+                }
             }
-        
         }
     }
 }


### PR DESCRIPTION
## Summary
- fade out splash logo before completing splash view

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68a7bf023c64832389952d42abf9748a