### PR TITLE
Add strategy bot polling and display

### DIFF
--- a/F1App/F1App/RaceDetailView.swift
+++ b/F1App/F1App/RaceDetailView.swift
@@ -13,6 +13,7 @@ struct RaceDetailView: View {
 
     @State private var selectedTab = 0
     @StateObject private var viewModel = HistoricalRaceViewModel()
+    @StateObject private var strategyViewModel = StrategyViewModel()
 
     var body: some View {
         VStack {
@@ -31,14 +32,18 @@ struct RaceDetailView: View {
                     .frame(height: UIScreen.main.bounds.height / 2)
                     .padding()
             } else if selectedTab == 1 {
-                Text("Section 2 content").font(.title)
+                List(strategyViewModel.messages, id: \.self) { msg in
+                    Text(msg)
+                }
             } else {
                 HistoricalRaceView(race: race, viewModel: viewModel)
             }
-            
+
             Spacer()
         }
         .navigationTitle(race.location)
         .navigationBarTitleDisplayMode(.inline)
+        .onAppear { strategyViewModel.start(sessionKey: race.id) }
+        .onDisappear { strategyViewModel.stop() }
     }
 }

--- a/F1App/F1App/Services/StrategyService.swift
+++ b/F1App/F1App/Services/StrategyService.swift
@@ -1,0 +1,36 @@
+import Foundation
+
+struct StrategyResponse: Decodable {
+    let messages: [String]?
+}
+
+final class StrategyService {
+    let session: URLSession
+    let baseURL: URL
+
+    init(session: URLSession = .shared, baseURL: URL = URL(string: APIConfig.baseURL)!) {
+        self.session = session
+        self.baseURL = baseURL
+    }
+
+    func fetchMessages(sessionKey: Int) async throws -> [String] {
+        var endpoint: URL
+        if baseURL.lastPathComponent == "api" {
+            endpoint = baseURL.appendingPathComponent("strategy")
+        } else {
+            endpoint = baseURL.appendingPathComponent("api").appendingPathComponent("strategy")
+        }
+
+        var comps = URLComponents(url: endpoint, resolvingAgainstBaseURL: false)!
+        comps.queryItems = [
+            URLQueryItem(name: "session_key", value: String(sessionKey)),
+            URLQueryItem(name: "all", value: "1")
+        ]
+        let url = comps.url!
+        let (data, _) = try await session.data(from: url)
+        let dec = JSONDecoder()
+        let resp = try dec.decode(StrategyResponse.self, from: data)
+        return resp.messages ?? []
+    }
+}
+

--- a/F1App/F1App/StrategyViewModel.swift
+++ b/F1App/F1App/StrategyViewModel.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+@MainActor
+class StrategyViewModel: ObservableObject {
+    @Published var messages: [String] = []
+    private let service: StrategyService
+    private var timer: Timer?
+
+    init(service: StrategyService = StrategyService()) {
+        self.service = service
+    }
+
+    func start(sessionKey: Int) {
+        fetch(sessionKey: sessionKey)
+        timer?.invalidate()
+        timer = Timer.scheduledTimer(withTimeInterval: 30, repeats: true) { [weak self] _ in
+            self?.fetch(sessionKey: sessionKey)
+        }
+    }
+
+    func stop() {
+        timer?.invalidate()
+        timer = nil
+    }
+
+    private func fetch(sessionKey: Int) {
+        Task {
+            do {
+                let msgs = try await service.fetchMessages(sessionKey: sessionKey)
+                self.messages = msgs
+            } catch {
+                print("Strategy fetch failed: \(error)")
+            }
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- Add `StrategyService` to query backend strategy bot and parse message array
- Create `StrategyViewModel` with 30s timer to refresh bot suggestions
- Integrate strategy messages into RaceDetailView section 2

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68ab0715bc40832390bd5e6daca21791