### PR TITLE
Fix strategy bot ISO8601 parsing

### DIFF
--- a/API/F1_API/app/Services/StrategyBot/strategy_bot_openf1.py
+++ b/API/F1_API/app/Services/StrategyBot/strategy_bot_openf1.py
@@ -31,7 +31,8 @@ def build_session_minute_frame(session_key: int) -> pd.DataFrame:
     drv = get_df('drivers', session_key=session_key)
     if pos.empty or drv.empty:
         return pd.DataFrame()
-    pos['minute'] = pd.to_datetime(pos['date']).dt.floor('min')
+    # openf1 timestamps may omit fractional seconds, so force ISO8601 parsing
+    pos['minute'] = pd.to_datetime(pos['date'], format='ISO8601').dt.floor('min')
     df = pos[['minute','driver_number','position']]
     df = df.merge(drv[['driver_number','full_name','team_name']], on='driver_number', how='left')
     return df


### PR DESCRIPTION
## Summary
- Fix F1 Strategy Bot to parse mixed OpenF1 timestamp formats by forcing ISO8601 parsing.

## Testing
- `php artisan test` *(fails: vendor/autoload.php missing)*
- `OF1_BASE=https://api.openf1.org/v1 python3 API/F1_API/app/Services/StrategyBot/strategy_bot_openf1.py --session-key 9472 | jq '.suggestions | length'`

------
https://chatgpt.com/codex/tasks/task_e_68ab9ad6836c8323a19e4c5aefe752e4