### PR TITLE
Show strategy suggestions for historical races

### DIFF
--- a/F1App/F1App/HistoricalRaceViewModel.swift
+++ b/F1App/F1App/HistoricalRaceViewModel.swift
@@ -134,6 +134,7 @@ class HistoricalRaceViewModel: ObservableObject {
 
     func load(for race: Race) {
         pause()
+        stopStrategyUpdates()
         stepIndex = 0
         positions.removeAll()
         currentPosition.removeAll()
@@ -230,6 +231,7 @@ class HistoricalRaceViewModel: ObservableObject {
                     self.fetchRaceControl(sessionKey: session.session_key)
                     self.fetchOvertakes(sessionKey: session.session_key)
                 }
+                self.startStrategyUpdates(sessionKey: session.session_key)
             }
         }.resume()
     }

--- a/F1App/F1App/RaceDetailView.swift
+++ b/F1App/F1App/RaceDetailView.swift
@@ -18,7 +18,7 @@ struct RaceDetailView: View {
         VStack {
             Picker("Select Section", selection: $selectedTab) {
                 Text("Circuit").tag(0)
-                Text("Section 2").tag(1)
+                Text("Strategie").tag(1)
                 Text("Curse istorice").tag(2)
             }
             .pickerStyle(SegmentedPickerStyle())
@@ -38,12 +38,6 @@ struct RaceDetailView: View {
                         Text(s.why).font(.caption)
                     }
                 }
-                .onAppear {
-                    if let sk = viewModel.sessionKey {
-                        viewModel.startStrategyUpdates(sessionKey: sk)
-                    }
-                }
-                .onDisappear { viewModel.stopStrategyUpdates() }
             } else {
                 HistoricalRaceView(race: race, viewModel: viewModel)
             }
@@ -52,5 +46,6 @@ struct RaceDetailView: View {
         }
         .navigationTitle(race.location)
         .navigationBarTitleDisplayMode(.inline)
+        .onDisappear { viewModel.stopStrategyUpdates() }
     }
 }


### PR DESCRIPTION
## Summary
- Rename second tab to "Strategie" and show strategy suggestions list
- Auto-start strategy data polling after resolving a historical race and stop timer when leaving view

## Testing
- ⚠️ `swiftc -typecheck F1App/RaceDetailView.swift F1App/HistoricalRaceViewModel.swift` *(fails: no such module 'SwiftUI')*


------
https://chatgpt.com/codex/tasks/task_e_68ab9e63be148323ac3e20ca4d1fec3b