### PR TITLE
Fix strategy API path for strategy updates

### DIFF
--- a/F1App/F1App/HistoricalRaceViewModel.swift
+++ b/F1App/F1App/HistoricalRaceViewModel.swift
@@ -124,7 +124,7 @@ class HistoricalRaceViewModel: ObservableObject {
     private func fetchStrategy(sessionKey: Int) {
         Task {
             do {
-                let resp: StrategyResponse = try await getJSON("/historical/session/\(sessionKey)/strategy")
+                let resp: StrategyResponse = try await getJSON("/api/historical/session/\(sessionKey)/strategy")
                 await MainActor.run { self.strategySuggestions = resp.suggestions }
             } catch {
                 await MainActor.run { self.errorMessage = "Nu pot prelua strategia" }


### PR DESCRIPTION
## Summary
- Prefix strategy fetch with `/api` to align with backend routes.

## Testing
- `swiftc -typecheck F1App/F1App/HistoricalRaceViewModel.swift` *(fails: no such module 'SwiftUI')*


------
https://chatgpt.com/codex/tasks/task_e_68aba0dded1483238dbba12f6bdbdd99