### PR TITLE
Use meeting key for strategy bot

### DIFF
--- a/API/F1_API/app/Console/Commands/StrategyBotRun.php
+++ b/API/F1_API/app/Console/Commands/StrategyBotRun.php
@@ -8,14 +8,14 @@ use Symfony\Component\Process\Process;
 
 class StrategyBotRun extends Command
 {
-    protected $signature = 'strategy:run {session_key}';
+    protected $signature = 'strategy:run {meeting_key}';
     protected $description = 'Run the F1 strategy bot and cache its suggestions';
 
     public function handle(): int
     {
-        $sessionKey = (int)$this->argument('session_key');
+        $meetingKey = (int)$this->argument('meeting_key');
         $script = base_path('app/Services/StrategyBot/strategy_bot_openf1.py');
-        $process = new Process(['python3', $script, '--session-key', (string)$sessionKey]);
+        $process = new Process(['python3', $script, '--meeting-key', (string)$meetingKey]);
         $process->run();
 
         if (! $process->isSuccessful()) {
@@ -26,7 +26,7 @@ class StrategyBotRun extends Command
         $output = $process->getOutput();
         try {
             $data = json_decode($output, true, flags: JSON_THROW_ON_ERROR);
-            Cache::put("strategy_suggestions_{$sessionKey}", $data, now()->addMinutes(10));
+            Cache::put("strategy_suggestions_{$meetingKey}", $data, now()->addMinutes(10));
             $this->info('Strategy suggestions cached.');
         } catch (\Throwable $e) {
             $this->error('Invalid JSON from bot: '.$e->getMessage());

--- a/API/F1_API/app/Console/Kernel.php
+++ b/API/F1_API/app/Console/Kernel.php
@@ -9,9 +9,9 @@ class Kernel extends ConsoleKernel
 {
     protected function schedule(Schedule $schedule): void
     {
-        $schedule->command('strategy:run', [cache('strategy_active_session')])
+        $schedule->command('strategy:run', [cache('strategy_active_meeting')])
             ->everyThirtySeconds()
-            ->when(fn () => cache()->has('strategy_active_session'));
+            ->when(fn () => cache()->has('strategy_active_meeting'));
     }
 
     protected function commands(): void

--- a/API/F1_API/app/Http/Controllers/HistoricalController.php
+++ b/API/F1_API/app/Http/Controllers/HistoricalController.php
@@ -43,7 +43,7 @@ class HistoricalController extends Controller
         }
 
         $session = $response->json()[0];
-        Cache::put('strategy_active_session', $session['session_key'], 600);
+        Cache::put('strategy_active_meeting', $session['meeting_key'], 600);
 
         return response()->json([
             'session_key' => $session['session_key'],

--- a/API/F1_API/app/Http/Controllers/StrategyController.php
+++ b/API/F1_API/app/Http/Controllers/StrategyController.php
@@ -6,9 +6,9 @@ use Illuminate\Support\Facades\Cache;
 
 class StrategyController extends Controller
 {
-    public function suggestions(int $sessionKey)
+    public function suggestions(int $meetingKey)
     {
-        $data = Cache::get("strategy_suggestions_{$sessionKey}");
+        $data = Cache::get("strategy_suggestions_{$meetingKey}");
         if (! $data) {
             return response()->json(['error' => 'No suggestions'], 404);
         }

--- a/API/F1_API/app/Services/StrategyBot/strategy_bot_openf1.py
+++ b/API/F1_API/app/Services/StrategyBot/strategy_bot_openf1.py
@@ -26,9 +26,9 @@ def get_df(endpoint: str, **params) -> pd.DataFrame:
     data = _http_get(endpoint, **params)
     return pd.DataFrame(data)
 
-def build_session_minute_frame(session_key: int) -> pd.DataFrame:
-    pos = get_df('position', session_key=session_key)
-    drv = get_df('drivers', session_key=session_key)
+def build_session_minute_frame(meeting_key: int) -> pd.DataFrame:
+    pos = get_df('position', meeting_key=meeting_key)
+    drv = get_df('drivers', meeting_key=meeting_key)
     if pos.empty or drv.empty:
         return pd.DataFrame()
     # openf1 timestamps may omit fractional seconds, so force ISO8601 parsing
@@ -37,8 +37,8 @@ def build_session_minute_frame(session_key: int) -> pd.DataFrame:
     df = df.merge(drv[['driver_number','full_name','team_name']], on='driver_number', how='left')
     return df
 
-def suggest_all_now(session_key: int) -> List[Dict]:
-    df = build_session_minute_frame(session_key)
+def suggest_all_now(meeting_key: int) -> List[Dict]:
+    df = build_session_minute_frame(meeting_key)
     if df.empty:
         return []
     latest = df[df['minute']==df['minute'].max()]
@@ -57,7 +57,7 @@ def suggest_all_now(session_key: int) -> List[Dict]:
 if __name__ == '__main__':
     import argparse
     p = argparse.ArgumentParser('F1 Strategy Bot (simplified)')
-    p.add_argument('--session-key', type=int, required=True)
+    p.add_argument('--meeting-key', type=int, required=True)
     args = p.parse_args()
-    sug = suggest_all_now(args.session_key)
-    print(json.dumps({'session_key': args.session_key, 'suggestions': sug}, indent=2))
+    sug = suggest_all_now(args.meeting_key)
+    print(json.dumps({'meeting_key': args.meeting_key, 'suggestions': sug}, indent=2))

--- a/API/F1_API/routes/api.php
+++ b/API/F1_API/routes/api.php
@@ -46,7 +46,7 @@ Route::prefix('historical')->middleware('throttle:120,1')->group(function () {
     Route::get('/session/{session_key}/events', [HistoricalController::class, 'events']);
     Route::get('/session/{session_key}/laps', [HistoricalController::class, 'laps']);
     Route::get('/session/{session_key}/frames', [HistoricalController::class, 'frames']);
-    Route::get('/session/{session_key}/strategy', [StrategyController::class, 'suggestions']);
+    Route::get('/meeting/{meeting_key}/strategy', [StrategyController::class, 'suggestions']);
 });
 Route::get('/health', fn () => response()->json(['ok' => true]));
 Route::get('/news/f1', [NewsController::class, 'f1Autosport']);

--- a/F1App/F1App/RaceDetailView.swift
+++ b/F1App/F1App/RaceDetailView.swift
@@ -39,8 +39,8 @@ struct RaceDetailView: View {
                     }
                 }
                 .onAppear {
-                    if let sk = viewModel.sessionKey {
-                        viewModel.startStrategyUpdates(sessionKey: sk)
+                    if let mk = viewModel.meetingKey {
+                        viewModel.startStrategyUpdates(meetingKey: mk)
                     }
                 }
                 .onDisappear { viewModel.stopStrategyUpdates() }


### PR DESCRIPTION
## Summary
- run strategy bot using meeting key instead of session key
- update iOS client to request strategy by meeting key

## Testing
- `php artisan test` *(fails: SQLSTATE[HY000] [2002] Connection refused)*
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68aba068196c832385c64fd5e1e7c911