### PR TITLE
Allow meeting_key alias for strategy bot

### DIFF
--- a/API/F1_API/app/Services/StrategyBot/strategy_bot_openf1.py
+++ b/API/F1_API/app/Services/StrategyBot/strategy_bot_openf1.py
@@ -69,7 +69,6 @@ def _coerce_driver_number(df: pd.DataFrame) -> pd.DataFrame:
 
 def get_df(endpoint: str, **params) -> pd.DataFrame:
     data = _http_get(endpoint, **params)
-<<<<<<< HEAD
     df = pd.DataFrame(data) if data else pd.DataFrame()
     # uniformizează cheile de merge & câteva câmpuri numerice
     df = _coerce_driver_number(df)
@@ -77,7 +76,6 @@ def get_df(endpoint: str, **params) -> pd.DataFrame:
         if col in df.columns:
             df[col] = pd.to_numeric(df[col], errors="coerce")
     return df
-
 def _parse_tplus(s: str) -> timedelta:
     s = (s or "").strip()
     parts = s.split(":")
@@ -93,23 +91,6 @@ def _parse_tplus(s: str) -> timedelta:
 # ========================= API wrappers (fără limit=) =========================
 def meetings_by_year(year: int) -> pd.DataFrame:
     df = get_df("meetings", year=int(year))
-=======
-    return pd.DataFrame(data)
-
-def build_session_minute_frame(meeting_key: int) -> pd.DataFrame:
-    pos = get_df('position', meeting_key=meeting_key)
-    drv = get_df('drivers', meeting_key=meeting_key)
-    if pos.empty or drv.empty:
-        return pd.DataFrame()
-    # openf1 timestamps may omit fractional seconds, so force ISO8601 parsing
-    pos['minute'] = pd.to_datetime(pos['date'], format='ISO8601').dt.floor('min')
-    df = pos[['minute','driver_number','position']]
-    df = df.merge(drv[['driver_number','full_name','team_name']], on='driver_number', how='left')
-    return df
-
-def suggest_all_now(meeting_key: int) -> List[Dict]:
-    df = build_session_minute_frame(meeting_key)
->>>>>>> 35d1832392b417e7f8b4fde0dd2e185ff5bcbd64
     if df.empty:
         df = get_df("meetings", **{
             "date_start>=": f"{year}-01-01T00:00:00Z",
@@ -679,10 +660,10 @@ def run_year(year: int) -> pd.DataFrame:
 # ========================= CLI =========================
 if __name__ == "__main__":
     import argparse
-<<<<<<< HEAD
     p = argparse.ArgumentParser("F1 Strategy Bot (OpenF1)")
     p.add_argument("--year", type=int, default=2025, help="An analizat (meeting-first).")
-    p.add_argument("--meeting-key", type=int, help="Rulează pe meeting-ul dat (Race).")
+    p.add_argument("--meeting-key", "--meeting_key", dest="meeting_key", type=int,
+                   help="Rulează pe meeting-ul dat (Race).")
     p.add_argument("--session-key", type=str, help="Race session_key (acceptă și 'latest').")
     p.add_argument("--all", action="store_true", help="Printează recomandări pentru TOȚI piloții.")
     p.add_argument("--minute", type=str, help="Timp absolut (UTC) ex. 2024-05-05T20:30:00Z.")
@@ -789,10 +770,3 @@ if __name__ == "__main__":
                 "minute": str(minute), "pit_loss_base": pit_loss,
                 "suggestion": sug
             }, indent=2, ensure_ascii=False))
-=======
-    p = argparse.ArgumentParser('F1 Strategy Bot (simplified)')
-    p.add_argument('--meeting-key', type=int, required=True)
-    args = p.parse_args()
-    sug = suggest_all_now(args.meeting_key)
-    print(json.dumps({'meeting_key': args.meeting_key, 'suggestions': sug}, indent=2))
->>>>>>> 35d1832392b417e7f8b4fde0dd2e185ff5bcbd64


### PR DESCRIPTION
## Summary
- clean Strategy Bot script and expose `--meeting_key` CLI flag
- keep `--tplus` support for offset from race start

## Testing
- `python API/F1_API/app/Services/StrategyBot/strategy_bot_openf1.py --help`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68abb0b20290832382730f1d39f0db20