### PR TITLE
Queue strategy bot and configure Python path

### DIFF
--- a/API/F1_API/.env.example
+++ b/API/F1_API/.env.example
@@ -70,3 +70,7 @@ AWS_USE_PATH_STYLE_ENDPOINT=false
 
 VITE_APP_NAME="${APP_NAME}"
 AUTOSPORT_RSS_TIMEOUT=10
+
+# Path to the Python interpreter for the strategy bot
+STRATEGY_BOT_PYTHON=/absolute/path/to/venv/bin/python
+

--- a/API/F1_API/app/Console/Commands/StrategyBotRun.php
+++ b/API/F1_API/app/Console/Commands/StrategyBotRun.php
@@ -3,35 +3,18 @@
 namespace App\Console\Commands;
 
 use Illuminate\Console\Command;
-use Illuminate\Support\Facades\Cache;
-use Symfony\Component\Process\Process;
+use App\Jobs\RunStrategyBot;
 
 class StrategyBotRun extends Command
 {
     protected $signature = 'strategy:run {meeting_key}';
-    protected $description = 'Run the F1 strategy bot and cache its suggestions';
+    protected $description = 'Dispatch the F1 strategy bot job';
 
     public function handle(): int
     {
-        $meetingKey = (int)$this->argument('meeting_key');
-        $script = base_path('app/Services/StrategyBot/strategy_bot_openf1.py');
-        $process = new Process(['python3', $script, '--meeting-key', (string)$meetingKey]);
-        $process->run();
-
-        if (! $process->isSuccessful()) {
-            $this->error($process->getErrorOutput());
-            return self::FAILURE;
-        }
-
-        $output = $process->getOutput();
-        try {
-            $data = json_decode($output, true, flags: JSON_THROW_ON_ERROR);
-            Cache::put("strategy_suggestions_{$meetingKey}", $data, now()->addMinutes(10));
-            $this->info('Strategy suggestions cached.');
-        } catch (\Throwable $e) {
-            $this->error('Invalid JSON from bot: '.$e->getMessage());
-            return self::FAILURE;
-        }
+        $meetingKey = (int) $this->argument('meeting_key');
+        RunStrategyBot::dispatch($meetingKey);
+        $this->info("Strategy bot job dispatched for meeting {$meetingKey}.");
 
         return self::SUCCESS;
     }

--- a/API/F1_API/app/Jobs/RunStrategyBot.php
+++ b/API/F1_API/app/Jobs/RunStrategyBot.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\Jobs;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Log;
+use Symfony\Component\Process\Process;
+
+class RunStrategyBot implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public function __construct(public int $meetingKey)
+    {
+    }
+
+    public function handle(): void
+    {
+        $python = config('strategy.python_path');
+        $script = base_path('app/Services/StrategyBot/strategy_bot_openf1.py');
+
+        $process = new Process([$python, $script, '--meeting-key', (string) $this->meetingKey]);
+        $process->run();
+
+        Log::info('strategy bot stdout', [
+            'meeting_key' => $this->meetingKey,
+            'stdout' => $process->getOutput(),
+        ]);
+
+        if (! $process->isSuccessful()) {
+            Log::error('strategy bot failed', [
+                'meeting_key' => $this->meetingKey,
+                'stderr' => $process->getErrorOutput(),
+            ]);
+            return;
+        }
+
+        try {
+            $data = json_decode($process->getOutput(), true, flags: JSON_THROW_ON_ERROR);
+            Cache::put("strategy_suggestions_{$this->meetingKey}", $data, now()->addMinutes(10));
+        } catch (\Throwable $e) {
+            Log::error('Invalid JSON from bot', [
+                'meeting_key' => $this->meetingKey,
+                'exception' => $e->getMessage(),
+            ]);
+        }
+    }
+}
+

--- a/API/F1_API/config/strategy.php
+++ b/API/F1_API/config/strategy.php
@@ -1,0 +1,7 @@
+<?php
+
+return [
+    // Absolute path to the Python interpreter inside the virtual environment
+    'python_path' => env('STRATEGY_BOT_PYTHON', base_path('app/Services/StrategyBot/.venv/bin/python')),
+];
+


### PR DESCRIPTION
## Summary
- Run strategy bot via queued job that logs stdout/stderr and caches results
- Dispatch job from `strategy:run` command instead of running Python inline
- Allow configuring absolute Python interpreter path via new `STRATEGY_BOT_PYTHON` env setting

## Testing
- `php artisan test` *(fails: SQLSTATE[HY000] [2002] Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68ac4404c5248323820541694828167a