### PR TITLE
Log HTTP errors for getJSON

### DIFF
--- a/F1App/F1App/API.swift
+++ b/F1App/F1App/API.swift
@@ -27,7 +27,13 @@ enum API {
 func getJSON<T: Decodable>(_ path: String, query: [String:String]? = nil) async throws -> T {
     let url = API.url(path, query: query)
     let (data, resp) = try await URLSession.shared.data(from: url)
-    guard let http = resp as? HTTPURLResponse, (200..<300).contains(http.statusCode) else {
+    guard let http = resp as? HTTPURLResponse else {
+        print("\u{1F6AB} Non-HTTP response for", url.absoluteString)
+        throw URLError(.badServerResponse)
+    }
+    guard (200..<300).contains(http.statusCode) else {
+        let body = String(data: data, encoding: .utf8) ?? "<non-UTF8 body>"
+        print("\u{274C} HTTP", http.statusCode, "for", url.absoluteString, "-", body)
         throw URLError(.badServerResponse)
     }
     return try JSONDecoder().decode(T.self, from: data)


### PR DESCRIPTION
## Summary
- log HTTP status and body when API responses are not 2xx
- log non-HTTP responses for easier debugging

## Testing
- ⚠️ `swift test` *(Package.swift not found)*

------
https://chatgpt.com/codex/tasks/task_e_68acd80714c0832395eb78c96a573952