### PR TITLE
feat: harden strategy bot integration

### DIFF
--- a/API/F1_API/.env.example
+++ b/API/F1_API/.env.example
@@ -73,4 +73,6 @@ AUTOSPORT_RSS_TIMEOUT=10
 
 # Path to the Python interpreter for the strategy bot
 STRATEGY_BOT_PYTHON=/absolute/path/to/venv/bin/python
+OF1_BASE=https://api.openf1.org/v1
+OF1_DEBUG=0
 

--- a/API/F1_API/README.md
+++ b/API/F1_API/README.md
@@ -7,6 +7,11 @@
 <a href="https://packagist.org/packages/laravel/framework"><img src="https://img.shields.io/packagist/l/laravel/framework" alt="License"></a>
 </p>
 
+## Strategy Bot Runbook
+
+For instructions on running the Python strategy bot and verifying the Laravel integration, see [docs/strategy-bot-runbook.md](docs/strategy-bot-runbook.md).
+Use `http://127.0.0.1:8000` when testing from iOS simulators to avoid IPv6 `.local` issues.
+
 ## About Laravel
 
 Laravel is a web application framework with expressive, elegant syntax. We believe development must be an enjoyable and creative experience to be truly fulfilling. Laravel takes the pain out of development by easing common tasks used in many web projects, such as:

--- a/API/F1_API/app/Console/Kernel.php
+++ b/API/F1_API/app/Console/Kernel.php
@@ -11,7 +11,8 @@ class Kernel extends ConsoleKernel
     {
         $schedule->command('strategy:run', [cache('strategy_active_meeting')])
             ->everyThirtySeconds()
-            ->when(fn () => cache()->has('strategy_active_meeting'));
+            ->when(fn () => cache()->has('strategy_active_meeting'))
+            ->withoutOverlapping();
     }
 
     protected function commands(): void

--- a/API/F1_API/app/Http/Controllers/StrategyController.php
+++ b/API/F1_API/app/Http/Controllers/StrategyController.php
@@ -2,16 +2,30 @@
 
 namespace App\Http\Controllers;
 
+use App\Jobs\RunStrategyBot;
 use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Log;
 
 class StrategyController extends Controller
 {
     public function suggestions(int $meetingKey)
     {
-        $data = Cache::get("strategy_suggestions_{$meetingKey}");
-        if (! $data) {
-            return response()->json(['error' => 'No suggestions'], 404);
+        $key = "strategy_suggestions_{$meetingKey}";
+        $data = Cache::get($key);
+        if ($data) {
+            Log::info('strategy suggestions cache hit', ['meeting_key' => $meetingKey]);
+            return response()->json($data);
         }
-        return response()->json($data);
+
+        Log::info('strategy suggestions cache miss', ['meeting_key' => $meetingKey]);
+        if (Cache::add("strategy_running_{$meetingKey}", true, 60)) {
+            RunStrategyBot::dispatch($meetingKey);
+            Log::info('strategy bot dispatched from controller', ['meeting_key' => $meetingKey]);
+        }
+
+        return response()->json([
+            'status' => 'queued',
+            'message' => 'Suggestions are being prepared. Try again shortly.',
+        ], 202);
     }
 }

--- a/API/F1_API/app/Jobs/RunStrategyBot.php
+++ b/API/F1_API/app/Jobs/RunStrategyBot.php
@@ -9,6 +9,7 @@ use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Str;
 use Symfony\Component\Process\Process;
 
 class RunStrategyBot implements ShouldQueue
@@ -22,32 +23,74 @@ class RunStrategyBot implements ShouldQueue
     public function handle(): void
     {
         $python = config('strategy.python_path');
-        $script = base_path('app/Services/StrategyBot/strategy_bot_openf1.py');
+        $script = config('strategy.script_path', base_path('app/Services/StrategyBot/strategy_bot_openf1.py'));
 
-        $process = new Process([$python, $script, '--meeting-key', (string) $this->meetingKey]);
+        if (! is_executable($python)) {
+            Log::error('strategy bot python not executable', ['python' => $python, 'meeting_key' => $this->meetingKey]);
+            Cache::forget("strategy_running_{$this->meetingKey}");
+            return;
+        }
+
+        if (! file_exists($script)) {
+            Log::error('strategy bot script missing', ['script' => $script, 'meeting_key' => $this->meetingKey]);
+            Cache::forget("strategy_running_{$this->meetingKey}");
+            return;
+        }
+
+        $env = [
+            'OF1_BASE' => config('strategy.of1_base'),
+            'OF1_DEBUG' => '1',
+        ];
+
+        $process = new Process([
+            $python,
+            $script,
+            '--meeting-key', (string) $this->meetingKey,
+            '--all',
+        ], base_path(), $env);
+
+        Log::info('running strategy bot', [
+            'meeting_key' => $this->meetingKey,
+            'cmd' => [$python, $script, '--meeting-key', (string) $this->meetingKey, '--all'],
+            'env' => $env,
+        ]);
+
         $process->run();
 
-        Log::info('strategy bot stdout', [
+        $stdout = Str::limit($process->getOutput(), 200);
+        $stderr = Str::limit($process->getErrorOutput(), 200);
+
+        Log::info('strategy bot finished', [
             'meeting_key' => $this->meetingKey,
-            'stdout' => $process->getOutput(),
+            'stdout' => $stdout,
+            'stderr' => $stderr,
         ]);
 
         if (! $process->isSuccessful()) {
+            Cache::forget("strategy_running_{$this->meetingKey}");
             Log::error('strategy bot failed', [
                 'meeting_key' => $this->meetingKey,
-                'stderr' => $process->getErrorOutput(),
+                'stderr' => $stderr,
             ]);
             return;
         }
 
         try {
             $data = json_decode($process->getOutput(), true, flags: JSON_THROW_ON_ERROR);
-            Cache::put("strategy_suggestions_{$this->meetingKey}", $data, now()->addMinutes(10));
+            Cache::put(
+                "strategy_suggestions_{$this->meetingKey}",
+                $data,
+                now()->addSeconds(config('strategy.cache_ttl'))
+            );
+            Log::info('strategy bot cached suggestions', ['meeting_key' => $this->meetingKey]);
         } catch (\Throwable $e) {
             Log::error('Invalid JSON from bot', [
                 'meeting_key' => $this->meetingKey,
+                'payload' => $stdout,
                 'exception' => $e->getMessage(),
             ]);
+        } finally {
+            Cache::forget("strategy_running_{$this->meetingKey}");
         }
     }
 }

--- a/API/F1_API/app/Services/StrategyBot/requirements.txt
+++ b/API/F1_API/app/Services/StrategyBot/requirements.txt
@@ -1,4 +1,5 @@
-requests
-pandas
-numpy
-scikit-learn
+requests>=2
+pandas>=2
+numpy>=1.24
+scikit-learn>=1.4
+urllib3<2

--- a/API/F1_API/config/strategy.php
+++ b/API/F1_API/config/strategy.php
@@ -3,5 +3,14 @@
 return [
     // Absolute path to the Python interpreter inside the virtual environment
     'python_path' => env('STRATEGY_BOT_PYTHON', base_path('app/Services/StrategyBot/.venv/bin/python')),
+
+    // Absolute path to the strategy bot script
+    'script_path' => env('STRATEGY_BOT_SCRIPT', base_path('app/Services/StrategyBot/strategy_bot_openf1.py')),
+
+    // Base URL for OpenF1-compatible API
+    'of1_base' => env('OF1_BASE', 'https://api.openf1.org/v1'),
+
+    // Cache TTL for strategy suggestions (seconds)
+    'cache_ttl' => env('STRATEGY_CACHE_TTL', 600),
 ];
 

--- a/API/F1_API/docs/strategy-bot-runbook.md
+++ b/API/F1_API/docs/strategy-bot-runbook.md
@@ -1,0 +1,40 @@
+# Strategy Bot Runbook
+
+## Commands
+
+```bash
+# Start queue worker
+php artisan queue:work
+
+# Populate cache for meeting 1262
+php artisan strategy:run 1262
+
+# Run Python directly (same args as job)
+OF1_BASE=https://api.openf1.org/v1 OF1_DEBUG=1 \
+python app/Services/StrategyBot/strategy_bot_openf1.py --meeting-key 1262 --all
+```
+
+## Test endpoint
+
+```bash
+curl -i http://127.0.0.1:8000/api/historical/meeting/1262/strategy
+# 200 with JSON after job writes to cache
+# 202 with {"status":"queued"} on miss (auto-dispatch)
+```
+*Use `127.0.0.1` instead of `.local` to avoid IPv6 resolution issues on iOS simulators.*
+
+## Verifications
+
+- `storage/logs/laravel.log` contains process command and env.
+- `php artisan tinker --execute="cache('strategy_suggestions_1262')"` returns array/JSON.
+- If `KeyError: 'session_type'`, confirm `_normalize_sessions()` runs and upstream data.
+- JSON invalid → log "Invalid JSON from bot", run script standalone and capture stdout.
+- Connection refused → ensure Laravel listening on `127.0.0.1:8000`.
+- Python path wrong → set `STRATEGY_BOT_PYTHON` correctly and reinstall dependencies.
+
+## Acceptance Criteria
+
+- `php artisan strategy:run 1262` stores cache key `strategy_suggestions_1262`.
+- `GET /api/historical/meeting/1262/strategy` returns 200 JSON after population and 202 queued on miss.
+- Job and manual runs share `OF1_BASE` and avoid `KeyError` due to normalization.
+- Logs include process command and request statuses when `OF1_DEBUG=1`.


### PR DESCRIPTION
## Summary
- configure strategy bot paths, base URL and caching
- normalize OpenF1 data in Python bot and add debug logging
- auto-dispatch strategy job on cache miss with queued response
- document runbook for running the strategy bot

## Testing
- `python -m py_compile app/Services/StrategyBot/strategy_bot_openf1.py`
- `php -l API/F1_API/app/Jobs/RunStrategyBot.php`
- `php -l API/F1_API/app/Http/Controllers/StrategyController.php`
- `php -l API/F1_API/app/Console/Kernel.php`
- `php artisan test` *(fails: Failed opening required 'vendor/autoload.php')*

------
https://chatgpt.com/codex/tasks/task_e_68acdca5db788323a7c72c1813c662c0