### PR TITLE
feat: add configurable strategy bot service

### DIFF
--- a/API/F1_API/.env.example
+++ b/API/F1_API/.env.example
@@ -72,7 +72,8 @@ VITE_APP_NAME="${APP_NAME}"
 AUTOSPORT_RSS_TIMEOUT=10
 
 # Path to the Python interpreter for the strategy bot
-STRATEGY_BOT_PYTHON=/absolute/path/to/venv/bin/python
+STRATEGY_BOT_PYTHON=/abs/path/to/.venv/bin/python
+STRATEGY_BOT_SCRIPT=app/Services/StrategyBot/strategy_bot_openf1.py
 OF1_BASE=https://api.openf1.org/v1
 OF1_DEBUG=0
 

--- a/API/F1_API/app/Console/Commands/StrategyBotRun.php
+++ b/API/F1_API/app/Console/Commands/StrategyBotRun.php
@@ -14,7 +14,10 @@ class StrategyBotRun extends Command
     {
         $meetingKey = (int) $this->argument('meeting_key');
         RunStrategyBot::dispatch($meetingKey);
-        $this->info("Strategy bot job dispatched for meeting {$meetingKey}.");
+
+        $python = config('strategy.python_path');
+        $script = config('strategy.script_path', base_path('app/Services/StrategyBot/strategy_bot_openf1.py'));
+        $this->info("Dispatched meeting {$meetingKey} using {$python} -> {$script}");
 
         return self::SUCCESS;
     }

--- a/API/F1_API/app/Http/Controllers/StrategyController.php
+++ b/API/F1_API/app/Http/Controllers/StrategyController.php
@@ -8,19 +8,23 @@ use Illuminate\Support\Facades\Log;
 
 class StrategyController extends Controller
 {
-    public function suggestions(int $meetingKey)
+    public function show(int $meeting)
     {
-        $key = "strategy_suggestions_{$meetingKey}";
+        $key = "strategy_suggestions_{$meeting}";
         $data = Cache::get($key);
         if ($data) {
-            Log::info('strategy suggestions cache hit', ['meeting_key' => $meetingKey]);
+            if (isset($data['suggestion']) && ! isset($data['suggestions'])) {
+                $data['suggestions'] = $data['suggestion'] ? [$data['suggestion']] : [];
+            }
+            Log::info('strategy suggestions cache hit', ['meeting_key' => $meeting]);
             return response()->json($data);
         }
 
-        Log::info('strategy suggestions cache miss', ['meeting_key' => $meetingKey]);
-        if (Cache::add("strategy_running_{$meetingKey}", true, 60)) {
-            RunStrategyBot::dispatch($meetingKey);
-            Log::info('strategy bot dispatched from controller', ['meeting_key' => $meetingKey]);
+        Log::info('strategy suggestions cache miss', ['meeting_key' => $meeting]);
+        $lock = Cache::lock("strategy_running_{$meeting}", 30);
+        if ($lock->get()) {
+            RunStrategyBot::dispatch($meeting);
+            Log::info('strategy bot dispatched from controller', ['meeting_key' => $meeting]);
         }
 
         return response()->json([

--- a/API/F1_API/config/strategy.php
+++ b/API/F1_API/config/strategy.php
@@ -2,13 +2,10 @@
 
 return [
     // Absolute path to the Python interpreter inside the virtual environment
-    'python_path' => env('STRATEGY_BOT_PYTHON', base_path('app/Services/StrategyBot/.venv/bin/python')),
+    'python_path' => env('STRATEGY_BOT_PYTHON', base_path('.venv/bin/python')),
 
     // Absolute path to the strategy bot script
     'script_path' => env('STRATEGY_BOT_SCRIPT', base_path('app/Services/StrategyBot/strategy_bot_openf1.py')),
-
-    // Base URL for OpenF1-compatible API
-    'of1_base' => env('OF1_BASE', 'https://api.openf1.org/v1'),
 
     // Cache TTL for strategy suggestions (seconds)
     'cache_ttl' => env('STRATEGY_CACHE_TTL', 600),

--- a/API/F1_API/docs/strategy-bot-runbook.md
+++ b/API/F1_API/docs/strategy-bot-runbook.md
@@ -1,15 +1,30 @@
 # Strategy Bot Runbook
 
-## Commands
+## Pornirea serverului
 
 ```bash
-# Start queue worker
+# IPv4 pe toate interfețele
+php artisan serve --host 0.0.0.0 --port 8000
+# IPv6 (pentru .local care se rezolvă la ::1)
+php artisan serve --host "::" --port 8000
+```
+
+## Client
+
+- Simulator iOS: `http://127.0.0.1:8000`
+- iPhone pe LAN: `http://<IP_LAN>:8000`
+
+## Queue
+
+```bash
 php artisan queue:work
-
-# Populate cache for meeting 1262
 php artisan strategy:run 1262
+php artisan tinker --execute="dump(cache('strategy_suggestions_1262'))"
+```
 
-# Run Python directly (same args as job)
+## Rulează Python identic cu jobul
+
+```bash
 OF1_BASE=https://api.openf1.org/v1 OF1_DEBUG=1 \
 python app/Services/StrategyBot/strategy_bot_openf1.py --meeting-key 1262 --all
 ```
@@ -18,23 +33,7 @@ python app/Services/StrategyBot/strategy_bot_openf1.py --meeting-key 1262 --all
 
 ```bash
 curl -i http://127.0.0.1:8000/api/historical/meeting/1262/strategy
-# 200 with JSON after job writes to cache
-# 202 with {"status":"queued"} on miss (auto-dispatch)
+# 202 {"status":"queued"} la prima lovire (cache miss)
+# 200 cu JSON după ce jobul scrie în cache
 ```
-*Use `127.0.0.1` instead of `.local` to avoid IPv6 resolution issues on iOS simulators.*
 
-## Verifications
-
-- `storage/logs/laravel.log` contains process command and env.
-- `php artisan tinker --execute="cache('strategy_suggestions_1262')"` returns array/JSON.
-- If `KeyError: 'session_type'`, confirm `_normalize_sessions()` runs and upstream data.
-- JSON invalid → log "Invalid JSON from bot", run script standalone and capture stdout.
-- Connection refused → ensure Laravel listening on `127.0.0.1:8000`.
-- Python path wrong → set `STRATEGY_BOT_PYTHON` correctly and reinstall dependencies.
-
-## Acceptance Criteria
-
-- `php artisan strategy:run 1262` stores cache key `strategy_suggestions_1262`.
-- `GET /api/historical/meeting/1262/strategy` returns 200 JSON after population and 202 queued on miss.
-- Job and manual runs share `OF1_BASE` and avoid `KeyError` due to normalization.
-- Logs include process command and request statuses when `OF1_DEBUG=1`.

--- a/API/F1_API/routes/api.php
+++ b/API/F1_API/routes/api.php
@@ -46,7 +46,7 @@ Route::prefix('historical')->middleware('throttle:120,1')->group(function () {
     Route::get('/session/{session_key}/events', [HistoricalController::class, 'events']);
     Route::get('/session/{session_key}/laps', [HistoricalController::class, 'laps']);
     Route::get('/session/{session_key}/frames', [HistoricalController::class, 'frames']);
-    Route::get('/meeting/{meeting_key}/strategy', [StrategyController::class, 'suggestions']);
+    Route::get('/meeting/{meeting}/strategy', [StrategyController::class, 'show']);
 });
 Route::get('/health', fn () => response()->json(['ok' => true]));
 Route::get('/news/f1', [NewsController::class, 'f1Autosport']);


### PR DESCRIPTION
## Summary
- Make Python strategy bot configurable via env and verbose logging
- Queue job launches bot with --all, parses JSON and caches suggestions
- Expose /api/historical/meeting/{meeting}/strategy with 202 on miss and runbook docs

## Testing
- `php -l app/Jobs/RunStrategyBot.php`
- `php -l app/Console/Commands/StrategyBotRun.php`
- `php -l app/Http/Controllers/StrategyController.php`
- `php -l routes/api.php`
- `python -m py_compile app/Services/StrategyBot/strategy_bot_openf1.py`
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68ace3799b0c83239c334e2dbbed40f5