### PR TITLE
Improve strategy bot command and IPv4 documentation

### DIFF
--- a/API/F1_API/.env.example
+++ b/API/F1_API/.env.example
@@ -2,7 +2,7 @@ APP_NAME=Laravel
 APP_ENV=local
 APP_KEY=
 APP_DEBUG=true
-APP_URL=http://localhost
+APP_URL=http://127.0.0.1:8000
 
 APP_LOCALE=en
 APP_FALLBACK_LOCALE=en

--- a/API/F1_API/app/Console/Commands/StrategyBotRun.php
+++ b/API/F1_API/app/Console/Commands/StrategyBotRun.php
@@ -17,7 +17,8 @@ class StrategyBotRun extends Command
 
         $python = config('strategy.python_path');
         $script = config('strategy.script_path', base_path('app/Services/StrategyBot/strategy_bot_openf1.py'));
-        $this->info("Dispatched meeting {$meetingKey} using {$python} -> {$script}");
+        $base = env('OF1_BASE', 'https://api.openf1.org/v1');
+        $this->info("Dispatched meeting {$meetingKey} using {$python} -> {$script} (OF1_BASE={$base})");
 
         return self::SUCCESS;
     }

--- a/API/F1_API/docs/strategy-bot-runbook.md
+++ b/API/F1_API/docs/strategy-bot-runbook.md
@@ -1,18 +1,17 @@
 # Strategy Bot Runbook
 
+To avoid `Connection refused` errors on `.local` names or IPv6 addresses, use **only IPv4** endpoints.
+
 ## Pornirea serverului
 
 ```bash
-# IPv4 pe toate interfețele
 php artisan serve --host 0.0.0.0 --port 8000
-# IPv6 (pentru .local care se rezolvă la ::1)
-php artisan serve --host "::" --port 8000
 ```
 
-## Client
+## Client (doar IPv4)
 
-- Simulator iOS: `http://127.0.0.1:8000`
-- iPhone pe LAN: `http://<IP_LAN>:8000`
+- Simulator iOS → `http://127.0.0.1:8000`
+- iPhone pe LAN → `http://<IP_LAN>:8000` (ex: `http://192.168.1.23:8000`)
 
 ## Queue
 


### PR DESCRIPTION
## Summary
- Print OF1_BASE when dispatching the strategy bot for clearer debugging
- Document IPv4-only workflow and remove IPv6 references in the strategy bot runbook
- Use an IPv4 `APP_URL` in `.env.example`

## Testing
- `php -l app/Console/Commands/StrategyBotRun.php`
- `php -l app/Jobs/RunStrategyBot.php`
- `php -l app/Http/Controllers/StrategyController.php`
- `python -m py_compile app/Services/StrategyBot/strategy_bot_openf1.py`


------
https://chatgpt.com/codex/tasks/task_e_68ace6f8b38083238bda9839e45c8698