### PR TITLE
Add strategy detail view and rename section

### DIFF
--- a/F1App/F1App/RaceDetailView.swift
+++ b/F1App/F1App/RaceDetailView.swift
@@ -18,7 +18,7 @@ struct RaceDetailView: View {
         VStack {
             Picker("Select Section", selection: $selectedTab) {
                 Text("Circuit").tag(0)
-                Text("Section 2").tag(1)
+                Text("Strategie").tag(1)
                 Text("Curse istorice").tag(2)
             }
             .pickerStyle(SegmentedPickerStyle())
@@ -32,10 +32,12 @@ struct RaceDetailView: View {
                     .padding()
             } else if selectedTab == 1 {
                 List(viewModel.strategySuggestions) { s in
-                    VStack(alignment: .leading) {
-                        Text(s.driver_name ?? "Driver \(s.driver_number ?? 0)").font(.headline)
-                        Text(s.advice).bold()
-                        Text(s.why).font(.caption)
+                    NavigationLink(destination: StrategyDetailView(suggestion: s)) {
+                        VStack(alignment: .leading) {
+                            Text(s.driver_name ?? "Driver \(s.driver_number ?? 0)").font(.headline)
+                            Text(s.advice).bold()
+                            Text(s.why).font(.caption)
+                        }
                     }
                 }
                 .onAppear {

--- a/F1App/F1App/StrategyDetailView.swift
+++ b/F1App/F1App/StrategyDetailView.swift
@@ -1,0 +1,34 @@
+import SwiftUI
+
+struct StrategyDetailView: View {
+    let suggestion: StrategySuggestion
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 8) {
+                Text(suggestion.driver_name ?? "Driver \(suggestion.driver_number ?? 0)")
+                    .font(.title)
+                if let team = suggestion.team {
+                    Text("Team: \(team)")
+                }
+                if let position = suggestion.position {
+                    Text("Position: \(position)")
+                }
+                Text("Advice: \(suggestion.advice)")
+                    .bold()
+                Text("Why: \(suggestion.why)")
+            }
+            .padding()
+        }
+        .navigationTitle("Strategie")
+    }
+}
+
+#Preview {
+    StrategyDetailView(suggestion: StrategySuggestion(driver_number: 1,
+                                                     driver_name: "Example Driver",
+                                                     team: "Example Team",
+                                                     position: 1,
+                                                     advice: "Pit now",
+                                                     why: "Fresh tires needed"))
+}


### PR DESCRIPTION
## Summary
- Rename "Section 2" tab to "Strategie" in race details
- Show each strategy suggestion as a link to a dedicated detail page
- Add `StrategyDetailView` to display full bot advice for a driver

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `swift --version`


------
https://chatgpt.com/codex/tasks/task_e_68adb298aa6883238ac75a808eb09b0d