### PR TITLE
Display 2025 race results and countdown in circuit view

### DIFF
--- a/F1App/F1App/CircuitView.swift
+++ b/F1App/F1App/CircuitView.swift
@@ -10,13 +10,6 @@ import SwiftUI
 struct CircuitView: View {
     let coordinatesJSON: String?
     @ObservedObject var viewModel: HistoricalRaceViewModel
-    struct DriverSelection: Identifiable {
-        let driver: DriverInfo
-        let point: LocationPoint
-        var id: Int { driver.driver_number }
-    }
-    @State private var selectedDriver: DriverSelection?
-
     init(coordinatesJSON: String?, viewModel: HistoricalRaceViewModel) {
         self.coordinatesJSON = coordinatesJSON
         self.viewModel = viewModel
@@ -68,42 +61,10 @@ struct CircuitView: View {
                         path.closeSubpath()
                     }
                     .stroke(Color.blue, lineWidth: 2)
-
-                    ForEach(viewModel.drivers) { driver in
-                        if let loc = viewModel.currentPosition[driver.driver_number] {
-                            let p = viewModel.point(for: loc, in: geo.size)
-                            Button {
-                                if let loc = viewModel.currentPosition[driver.driver_number] {
-                                    selectedDriver = DriverSelection(driver: driver, point: loc)
-                                }
-                            } label: {
-                                ZStack {
-                                    Circle()
-                                        .fill(Color.red)
-                                        .frame(width: 8, height: 8)
-                                    Text(driver.initials)
-                                        .font(.caption2)
-                                        .offset(y: -10)
-                                }
-                            }
-                            .buttonStyle(PlainButtonStyle())
-                            .position(p)
-                        }
-                    }
                 }
                 .animation(.linear(duration: 1), value: viewModel.stepIndex)
                 .background(Color.gray.opacity(0.1))
                 .cornerRadius(8)
-                .sheet(item: $selectedDriver) { selection in
-                    if let sk = viewModel.sessionKey {
-                        DriverDetailView(
-                            driver: selection.driver,
-                            sessionKey: sk,
-                            raceViewModel: viewModel
-                        )
-                    }
-
-                }
             }
         }
     }

--- a/F1App/F1App/CountdownView.swift
+++ b/F1App/F1App/CountdownView.swift
@@ -1,0 +1,30 @@
+import SwiftUI
+
+struct CountdownView: View {
+    let targetDate: Date
+    @State private var now: Date = Date()
+    private let timer = Timer.publish(every: 1, on: .main, in: .common).autoconnect()
+
+    var body: some View {
+        Text(timeRemaining)
+            .font(.headline)
+            .onReceive(timer) { _ in
+                now = Date()
+            }
+    }
+
+    private var timeRemaining: String {
+        let diff = Int(targetDate.timeIntervalSince(now))
+        if diff <= 0 { return "Cursa a început" }
+        let days = diff / 86_400
+        let hours = (diff % 86_400) / 3_600
+        let minutes = (diff % 3_600) / 60
+        let seconds = diff % 60
+        if days > 0 {
+            return String(format: "%dd %02dh %02dm %02ds", days, hours, minutes, seconds)
+        } else {
+            return String(format: "%02dh %02dm %02ds", hours, minutes, seconds)
+        }
+    }
+}
+

--- a/F1App/F1App/RaceDetailView.swift
+++ b/F1App/F1App/RaceDetailView.swift
@@ -14,6 +14,12 @@ struct RaceDetailView: View {
     @State private var selectedTab = 0
     @StateObject private var viewModel = HistoricalRaceViewModel()
 
+    private var raceDate: Date? {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd"
+        return formatter.date(from: race.date)
+    }
+
     var body: some View {
         VStack {
             Picker("Select Section", selection: $selectedTab) {
@@ -27,9 +33,19 @@ struct RaceDetailView: View {
             Spacer()
             
             if selectedTab == 0 {
-                CircuitView(coordinatesJSON: race.coordinates, viewModel: viewModel)
-                    .frame(height: UIScreen.main.bounds.height / 2)
-                    .padding()
+                if race.date.hasPrefix("2025") && race.status.lowercased() == "finished" {
+                    RaceResultsView(race: race)
+                } else {
+                    VStack {
+                        CircuitView(coordinatesJSON: race.coordinates, viewModel: viewModel)
+                            .frame(height: UIScreen.main.bounds.height / 2)
+                            .padding()
+                        if let d = raceDate {
+                            CountdownView(targetDate: d)
+                                .padding(.bottom)
+                        }
+                    }
+                }
             } else if selectedTab == 1 {
                 List(viewModel.strategySuggestions) { s in
                     NavigationLink(destination: StrategyDetailView(suggestion: s)) {

--- a/F1App/F1App/RaceResultsView.swift
+++ b/F1App/F1App/RaceResultsView.swift
@@ -1,0 +1,97 @@
+import SwiftUI
+
+struct RaceResultsView: View {
+    let race: Race
+    @StateObject private var viewModel = RaceResultsViewModel()
+
+    var body: some View {
+        List(viewModel.results) { result in
+            HStack {
+                Text(result.position)
+                    .frame(width: 30, alignment: .leading)
+                AsyncImage(url: result.imageURL) { image in
+                    image
+                        .resizable()
+                        .frame(width: 40, height: 40)
+                        .clipShape(Circle())
+                } placeholder: {
+                    Circle()
+                        .fill(Color.gray.opacity(0.3))
+                        .frame(width: 40, height: 40)
+                }
+                VStack(alignment: .leading) {
+                    Text(result.driverName)
+                    Text("\(result.points) pct")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+            }
+        }
+        .task { await viewModel.loadResults(for: race) }
+    }
+}
+
+struct RaceResultItem: Identifiable {
+    let id = UUID()
+    let position: String
+    let driverName: String
+    let points: String
+    let driverId: String
+
+    var imageURL: URL? {
+        let slug = driverId.replacingOccurrences(of: "_", with: "-")
+        return URL(string: "https://media.formula1.com/content/dam/fom-website/drivers/2024Drivers/\(slug).png")
+    }
+}
+
+class RaceResultsViewModel: ObservableObject {
+    @Published var results: [RaceResultItem] = []
+
+    func loadResults(for race: Race) async {
+        guard let url = URL(string: "https://ergast.com/api/f1/2025/\(race.id)/results.json") else { return }
+        do {
+            let (data, _) = try await URLSession.shared.data(from: url)
+            let decoded = try JSONDecoder().decode(ErgastResponse.self, from: data)
+            let items = decoded.MRData.RaceTable.Races.first?.Results ?? []
+            await MainActor.run {
+                self.results = items.map {
+                    RaceResultItem(position: $0.position,
+                                   driverName: "\($0.Driver.givenName) \($0.Driver.familyName)",
+                                   points: $0.points,
+                                   driverId: $0.Driver.driverId)
+                }
+            }
+        } catch {
+            // Ignoră erorile de rețea
+        }
+    }
+}
+
+struct ErgastResponse: Decodable {
+    let MRData: MRData
+
+    struct MRData: Decodable {
+        let RaceTable: RaceTable
+    }
+
+    struct RaceTable: Decodable {
+        let Races: [Race]
+    }
+
+    struct Race: Decodable {
+        let Results: [Result]
+    }
+
+    struct Result: Decodable {
+        let position: String
+        let points: String
+        let Driver: Driver
+    }
+
+    struct Driver: Decodable {
+        let driverId: String
+        let givenName: String
+        let familyName: String
+    }
+}
+


### PR DESCRIPTION
## Summary
- Remove driver markers from circuit rendering
- Show race results with driver images for completed 2025 events
- Display circuit with countdown timer for upcoming races

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68adb5a3d60483239f681f8b0d1477e5