### PR TITLE
Display driver images in standings

### DIFF
--- a/F1App/F1App/DriverStanding.swift
+++ b/F1App/F1App/DriverStanding.swift
@@ -15,6 +15,13 @@ struct DriverStanding: Decodable {
         let country_code: String
 }
 
+extension DriverStanding {
+    /// Returns the resource name for the driver's image based on their last name.
+    var imageName: String {
+        name.split(separator: " ").last.map(String.init) ?? name
+    }
+}
+
 func fetchStandings(completion: @escaping ([DriverStanding]?) -> Void) {
     let url = API.url("/api/drivers")
 

--- a/F1App/F1App/StandingsView.swift
+++ b/F1App/F1App/StandingsView.swift
@@ -19,13 +19,20 @@ struct StandingsView: View {
                 List {
                     if selectedTab == "Piloți" {
                         ForEach(standings.sorted(by: { $0.points > $1.points }), id: \.id) { standing in
-                            VStack(alignment: .leading) {
-                                Text(standing.name)
-                                    .font(.headline)
-                                Text(standing.team)
-                                    .font(.subheadline)
-                                Text("Puncte: \(standing.points)")
-                                    .font(.subheadline)
+                            HStack(spacing: 12) {
+                                Image("Images/\(standing.imageName)")
+                                    .resizable()
+                                    .scaledToFit()
+                                    .frame(width: 40, height: 40)
+                                    .clipShape(Circle())
+                                VStack(alignment: .leading) {
+                                    Text(standing.name)
+                                        .font(.headline)
+                                    Text(standing.team)
+                                        .font(.subheadline)
+                                    Text("Puncte: \(standing.points)")
+                                        .font(.subheadline)
+                                }
                             }
                             .padding(.vertical, 4)
                         }


### PR DESCRIPTION
## Summary
- derive driver image names from last names
- show driver photos in the pilots standings list

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68adbb592b8c832394528638f936f2bc