### PR TITLE
Fix driver image loading in standings

### DIFF
--- a/F1App/F1App/DriverStanding.swift
+++ b/F1App/F1App/DriverStanding.swift
@@ -18,7 +18,15 @@ struct DriverStanding: Decodable {
 extension DriverStanding {
     /// Returns the resource name for the driver's image based on their last name.
     var imageName: String {
-        name.split(separator: " ").last.map(String.init) ?? name
+        let lastName = name.split(separator: " ").last.map(String.init) ?? name
+        switch lastName.lowercased() {
+        case "russell":
+            return "Russel"
+        case "colapinto":
+            return "Colopinto"
+        default:
+            return lastName.capitalized
+        }
     }
 }
 

--- a/F1App/F1App/Image+Driver.swift
+++ b/F1App/F1App/Image+Driver.swift
@@ -1,0 +1,16 @@
+import SwiftUI
+import UIKit
+
+extension Image {
+    /// Loads a driver image from the bundled Images directory.
+    /// - Parameter name: Driver image base name (e.g., "Albon").
+    /// - Returns: SwiftUI Image loaded from disk or a default system image if not found.
+    static func driver(named name: String) -> Image {
+        if let path = Bundle.main.path(forResource: "Images/\(name).webp", ofType: "avif"),
+           let uiImage = UIImage(contentsOfFile: path) {
+            return Image(uiImage: uiImage)
+        }
+        return Image(systemName: "person.circle")
+    }
+}
+

--- a/F1App/F1App/StandingsView.swift
+++ b/F1App/F1App/StandingsView.swift
@@ -20,7 +20,7 @@ struct StandingsView: View {
                     if selectedTab == "Piloți" {
                         ForEach(standings.sorted(by: { $0.points > $1.points }), id: \.id) { standing in
                             HStack(spacing: 12) {
-                                Image("Images/\(standing.imageName)")
+                                Image.driver(named: standing.imageName)
                                     .resizable()
                                     .scaledToFit()
                                     .frame(width: 40, height: 40)


### PR DESCRIPTION
## Summary
- Load driver portraits from bundled images with a new helper
- Normalize driver last names to match bundled file names
- Use helper in standings view to display each driver's image

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68adbcf9a5588323aa930ccfca15993c