### PR TITLE
Support multiple driver image formats

### DIFF
--- a/F1App/F1App/Image+Driver.swift
+++ b/F1App/F1App/Image+Driver.swift
@@ -6,10 +6,19 @@ extension Image {
     /// - Parameter name: Driver image base name (e.g., "Albon").
     /// - Returns: SwiftUI Image loaded from disk or a default system image if not found.
     static func driver(named name: String) -> Image {
-        if let path = Bundle.main.path(forResource: "Images/\(name).webp", ofType: "avif"),
-           let uiImage = UIImage(contentsOfFile: path) {
-            return Image(uiImage: uiImage)
+        let candidates: [(String, String)] = [
+            ("Images/\(name)", "png"),
+            ("Images/\(name)", "jpg"),
+            ("Images/\(name).webp", "avif")
+        ]
+
+        for (resource, ext) in candidates {
+            if let path = Bundle.main.path(forResource: resource, ofType: ext),
+               let uiImage = UIImage(contentsOfFile: path) {
+                return Image(uiImage: uiImage)
+            }
         }
+
         return Image(systemName: "person.circle")
     }
 }


### PR DESCRIPTION
## Summary
- allow loading driver images from PNG, JPG, and AVIF
- default to system person icon when no image is found

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68ae089a79848323aa84541afb543e29