### PR TITLE
Show only top portion of news images

### DIFF
--- a/F1App/F1App/Views/NewsCard.swift
+++ b/F1App/F1App/Views/NewsCard.swift
@@ -6,20 +6,12 @@ struct NewsCard: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
             if let url = item.imageUrl {
-                AsyncImage(url: url) { image in
-                    image.resizable()
-                        .aspectRatio(16/9, contentMode: .fill)
-                        .clipped()
-                } placeholder: {
-                    Rectangle()
-                        .fill(Color.gray.opacity(0.3))
-                        .aspectRatio(16/9, contentMode: .fit)
-                }
-                .accessibilityLabel(item.title)
+                TopCroppedAsyncImage(url: url)
+                    .accessibilityLabel(item.title)
             } else {
                 Rectangle()
                     .fill(Color.gray.opacity(0.3))
-                    .aspectRatio(16/9, contentMode: .fit)
+                    .aspectRatio(16 / (9 * 0.3), contentMode: .fit)
             }
 
             Text(item.title)

--- a/F1App/F1App/Views/NewsDetailView.swift
+++ b/F1App/F1App/Views/NewsDetailView.swift
@@ -8,12 +8,8 @@ struct NewsDetailView: View {
         ScrollView {
             VStack(alignment: .leading, spacing: 16) {
                 if let url = item.imageUrl {
-                    AsyncImage(url: url) { image in
-                        image.resizable().aspectRatio(contentMode: .fit)
-                    } placeholder: {
-                        Rectangle().fill(Color.gray.opacity(0.3)).aspectRatio(16/9, contentMode: .fit)
-                    }
-                    .accessibilityLabel(item.title)
+                    TopCroppedAsyncImage(url: url)
+                        .accessibilityLabel(item.title)
                 }
 
                 Text(item.title)

--- a/F1App/F1App/Views/TopCroppedAsyncImage.swift
+++ b/F1App/F1App/Views/TopCroppedAsyncImage.swift
@@ -1,0 +1,30 @@
+import SwiftUI
+
+/// Loads an image and shows only the top portion with a small zoom.
+/// The visible height is roughly the top 30% of a 16:9 image.
+struct TopCroppedAsyncImage: View {
+    let url: URL
+    private let visibleRatio = 0.3
+
+    var body: some View {
+        GeometryReader { geo in
+            AsyncImage(url: url) { image in
+                image.resizable()
+                    .scaledToFill()
+                    .scaleEffect(1.1, anchor: .top)
+                    .frame(width: geo.size.width,
+                           height: geo.size.height / visibleRatio,
+                           alignment: .top)
+                    .clipped()
+            } placeholder: {
+                Rectangle()
+                    .fill(Color.gray.opacity(0.3))
+            }
+        }
+        .aspectRatio(16 / (9 * visibleRatio), contentMode: .fit)
+    }
+}
+
+#Preview {
+    TopCroppedAsyncImage(url: URL(string: "https://example.com/image.jpg")!)
+}


### PR DESCRIPTION
## Summary
- add TopCroppedAsyncImage to display only top ~30% of an image with slight zoom
- use TopCroppedAsyncImage in news card and detail views

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68ae0b5fb8988323b80e4d6f1ddc9aff