### PR TITLE
Zoom cropped driver images in standings

### DIFF
--- a/F1App/F1App/StandingsView.swift
+++ b/F1App/F1App/StandingsView.swift
@@ -22,8 +22,10 @@ struct StandingsView: View {
                             HStack(spacing: 12) {
                                 Image.driver(named: standing.imageName)
                                     .resizable()
-                                    .scaledToFit()
-                                    .frame(width: 40, height: 40)
+                                    .scaledToFill()
+                                    .frame(width: 40, height: 40, alignment: .top)
+                                    .scaleEffect(1.3, anchor: .top)
+                                    .clipped()
                                     .clipShape(Circle())
                                 VStack(alignment: .leading) {
                                     Text(standing.name)


### PR DESCRIPTION
## Summary
- crop driver images to the top portion with slight zoom in standings list

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68ae0d8a42fc8323a8b7cae95f35b108