### PR TITLE
Move driver images to right in standings

### DIFF
--- a/F1App/F1App/StandingsView.swift
+++ b/F1App/F1App/StandingsView.swift
@@ -20,13 +20,6 @@ struct StandingsView: View {
                     if selectedTab == "Piloți" {
                         ForEach(standings.sorted(by: { $0.points > $1.points }), id: \.id) { standing in
                             HStack(spacing: 12) {
-                                Image.driver(named: standing.imageName)
-                                    .resizable()
-                                    .scaledToFill()
-                                    .frame(width: 40, height: 40, alignment: .top)
-                                    .scaleEffect(1.3, anchor: .top)
-                                    .clipped()
-                                    .clipShape(Circle())
                                 VStack(alignment: .leading) {
                                     Text(standing.name)
                                         .font(.headline)
@@ -35,6 +28,14 @@ struct StandingsView: View {
                                     Text("Puncte: \(standing.points)")
                                         .font(.subheadline)
                                 }
+                                Spacer()
+                                Image.driver(named: standing.imageName)
+                                    .resizable()
+                                    .scaledToFill()
+                                    .frame(width: 40, height: 40, alignment: .top)
+                                    .scaleEffect(1.3, anchor: .top)
+                                    .clipped()
+                                    .clipShape(Circle())
                             }
                             .padding(.vertical, 4)
                         }


### PR DESCRIPTION
## Summary
- Place driver text before image and add spacer so driver photos appear on the right side of the standings list

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68ae0e6d358883238e4d9f82b231e4b3