### PR TITLE
Enlarge driver images in standings

### DIFF
--- a/F1App/F1App/StandingsView.swift
+++ b/F1App/F1App/StandingsView.swift
@@ -32,8 +32,8 @@ struct StandingsView: View {
                                 Image.driver(named: standing.imageName)
                                     .resizable()
                                     .scaledToFill()
-                                    .frame(width: 40, height: 40, alignment: .top)
-                                    .scaleEffect(1.3, anchor: .top)
+                                    .frame(width: 60, height: 60, alignment: .top)
+                                    .scaleEffect(1.5, anchor: .top)
                                     .clipped()
                                     .clipShape(Circle())
                             }


### PR DESCRIPTION
## Summary
- Enlarge pilot images in the classification standings view
- Increase zoom factor for driver photos

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68ae0fddb3e08323b192cc23a85edd59