### PR TITLE
Add design system and team color support

### DIFF
--- a/API/F1_API/app/Http/Controllers/TeamColorController.php
+++ b/API/F1_API/app/Http/Controllers/TeamColorController.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Support\Facades\DB;
+
+class TeamColorController extends Controller
+{
+    public function index()
+    {
+        $teams = DB::table('teams')
+            ->select('id', 'name', 'primary_color as primary', 'secondary_color as secondary')
+            ->get();
+
+        return response()->json(['teams' => $teams]);
+    }
+}

--- a/API/F1_API/routes/api.php
+++ b/API/F1_API/routes/api.php
@@ -13,6 +13,7 @@ use App\Http\Controllers\LiveController;
 use App\Http\Controllers\HistoricalController;
 use App\Http\Controllers\StrategyController;
 use App\Http\Controllers\NewsController;
+use App\Http\Controllers\TeamColorController;
 
 Route::post('/login', [AuthController::class, 'login']);
 Route::post('/register', [AuthController::class, 'register']);
@@ -50,4 +51,5 @@ Route::prefix('historical')->middleware('throttle:120,1')->group(function () {
 });
 Route::get('/health', fn () => response()->json(['ok' => true]));
 Route::get('/news/f1', [NewsController::class, 'f1Autosport']);
+Route::get('/teams/colors', [TeamColorController::class, 'index']);
 

--- a/F1App/F1App/Components/Card.swift
+++ b/F1App/F1App/Components/Card.swift
@@ -1,0 +1,16 @@
+import SwiftUI
+
+struct Card<Content: View>: View {
+    private let content: Content
+    init(@ViewBuilder content: () -> Content) {
+        self.content = content()
+    }
+    var body: some View {
+        content
+            .padding()
+            .background(AppColors.surface)
+            .cornerRadius(20)
+            .overlay(RoundedRectangle(cornerRadius: 20).stroke(AppColors.stroke, lineWidth: 1))
+            .shadow(color: Color.black.opacity(0.05), radius: 4, x: 0, y: 2)
+    }
+}

--- a/F1App/F1App/Components/DriverRow.swift
+++ b/F1App/F1App/Components/DriverRow.swift
@@ -1,0 +1,38 @@
+import SwiftUI
+
+struct DriverRow: View {
+    @EnvironmentObject var colorStore: TeamColorStore
+    let position: Int?
+    let driverNumber: Int?
+    let driverName: String
+    let teamName: String
+    let trend: Int?
+
+    var body: some View {
+        HStack(spacing: 12) {
+            if let position = position {
+                Text("\(position)")
+                    .frame(width: 24)
+                    .foregroundColor(AppColors.textSecondary)
+            }
+            Circle()
+                .fill(colorStore.color(forTeamName: teamName))
+                .frame(width: 32, height: 32)
+                .overlay(Text(driverNumber.map(String.init) ?? "").foregroundColor(.white))
+            VStack(alignment: .leading, spacing: 2) {
+                Text(driverName)
+                    .bodyStyle()
+                    .foregroundColor(AppColors.textPrimary)
+                Text(teamName)
+                    .captionStyle()
+                    .foregroundColor(AppColors.textSecondary)
+            }
+            Spacer()
+            if let trend = trend {
+                Image(systemName: trend >= 0 ? "arrow.up" : "arrow.down")
+                    .foregroundColor(trend >= 0 ? .green : .red)
+            }
+        }
+        .padding(.vertical, 4)
+    }
+}

--- a/F1App/F1App/Components/StateViews.swift
+++ b/F1App/F1App/Components/StateViews.swift
@@ -1,0 +1,35 @@
+import SwiftUI
+
+struct QueuedView: View {
+    var body: some View {
+        VStack(spacing: 8) {
+            ProgressView()
+            Text("Sugestia este în curs de procesare...")
+                .bodyStyle()
+                .foregroundColor(AppColors.textSecondary)
+        }
+        .padding()
+    }
+}
+
+struct EmptyStateView: View {
+    var body: some View {
+        Text("Nicio sugestie disponibilă")
+            .bodyStyle()
+            .foregroundColor(AppColors.textSecondary)
+            .padding()
+    }
+}
+
+struct ErrorBanner: View {
+    let message: String
+    var body: some View {
+        Text(message)
+            .bodyStyle()
+            .foregroundColor(.white)
+            .padding()
+            .frame(maxWidth: .infinity)
+            .background(AppColors.accentRed)
+            .cornerRadius(8)
+    }
+}

--- a/F1App/F1App/Components/StrategySuggestionCard.swift
+++ b/F1App/F1App/Components/StrategySuggestionCard.swift
@@ -1,0 +1,25 @@
+import SwiftUI
+
+struct StrategySuggestionCard: View {
+    @EnvironmentObject var colorStore: TeamColorStore
+    let suggestion: StrategySuggestion
+
+    var body: some View {
+        Card {
+            VStack(alignment: .leading, spacing: 8) {
+                DriverRow(position: suggestion.position,
+                          driverNumber: suggestion.driver_number,
+                          driverName: suggestion.driver_name ?? "Driver \(suggestion.driver_number ?? 0)",
+                          teamName: suggestion.team ?? "",
+                          trend: nil)
+                Text(suggestion.advice)
+                    .titleL()
+                    .foregroundColor(AppColors.textPrimary)
+                Text(suggestion.why)
+                    .bodyStyle()
+                    .foregroundColor(AppColors.textSecondary)
+            }
+        }
+        .animation(.interpolatingSpring(stiffness: 220, damping: 28), value: suggestion.id)
+    }
+}

--- a/F1App/F1App/Components/TeamChip.swift
+++ b/F1App/F1App/Components/TeamChip.swift
@@ -1,0 +1,16 @@
+import SwiftUI
+
+struct TeamChip: View {
+    @EnvironmentObject var colorStore: TeamColorStore
+    let teamId: Int?
+    let teamName: String
+
+    var body: some View {
+        Text(teamName)
+            .padding(.horizontal, 12)
+            .padding(.vertical, 6)
+            .background(colorStore.color(forTeamId: teamId))
+            .foregroundColor(.white)
+            .clipShape(Capsule())
+    }
+}

--- a/F1App/F1App/DesignSystem/AppColors.swift
+++ b/F1App/F1App/DesignSystem/AppColors.swift
@@ -1,0 +1,20 @@
+import SwiftUI
+
+struct AppColors {
+    static let background = Color { scheme in
+        scheme == .dark ? Color(hex: "#0A0A0A") : Color(hex: "#FFFFFF")
+    }
+    static let surface = Color { scheme in
+        scheme == .dark ? Color(hex: "#1A1A1A") : Color(hex: "#F5F5F5")
+    }
+    static let textPrimary = Color { scheme in
+        scheme == .dark ? Color(hex: "#FFFFFF") : Color(hex: "#0A0A0A")
+    }
+    static let textSecondary = Color { scheme in
+        scheme == .dark ? Color(hex: "#CCCCCC") : Color(hex: "#555555")
+    }
+    static let accentRed = Color(hex: "#E10600")
+    static let stroke = Color { scheme in
+        scheme == .dark ? Color.white.opacity(0.1) : Color.black.opacity(0.1)
+    }
+}

--- a/F1App/F1App/DesignSystem/AppShimmer.swift
+++ b/F1App/F1App/DesignSystem/AppShimmer.swift
@@ -1,0 +1,30 @@
+import SwiftUI
+
+struct AppShimmer: ViewModifier {
+    @State private var phase: CGFloat = 0
+    func body(content: Content) -> some View {
+        content
+            .redacted(reason: .placeholder)
+            .overlay(
+                LinearGradient(gradient: Gradient(colors: [Color.white.opacity(0.3), Color.white.opacity(0.9), Color.white.opacity(0.3)]), startPoint: .topLeading, endPoint: .bottomTrailing)
+                    .mask(content)
+                    .rotationEffect(.degrees(30))
+                    .offset(x: phase)
+            )
+            .onAppear {
+                withAnimation(.linear(duration: 1.2).repeatForever(autoreverses: false)) {
+                    phase = 200
+                }
+            }
+    }
+}
+
+extension View {
+    func shimmer(_ active: Bool = true) -> some View {
+        modifier(active ? AppShimmer() : SelfModifier())
+    }
+}
+
+private struct SelfModifier: ViewModifier {
+    func body(content: Content) -> some View { content }
+}

--- a/F1App/F1App/DesignSystem/AppTypography.swift
+++ b/F1App/F1App/DesignSystem/AppTypography.swift
@@ -1,0 +1,16 @@
+import SwiftUI
+
+extension View {
+    func titleXL() -> some View {
+        self.font(.system(size: 28, weight: .bold, design: .default))
+    }
+    func titleL() -> some View {
+        self.font(.system(size: 22, weight: .semibold, design: .default))
+    }
+    func bodyStyle() -> some View {
+        self.font(.system(size: 16, weight: .regular, design: .default))
+    }
+    func captionStyle() -> some View {
+        self.font(.system(size: 13, weight: .regular, design: .default))
+    }
+}

--- a/F1App/F1App/DesignSystem/Haptics.swift
+++ b/F1App/F1App/DesignSystem/Haptics.swift
@@ -1,0 +1,13 @@
+import UIKit
+
+enum Haptics {
+    static func lightTap() {
+        UIImpactFeedbackGenerator(style: .light).impactOccurred()
+    }
+    static func success() {
+        UINotificationFeedbackGenerator().notificationOccurred(.success)
+    }
+    static func error() {
+        UINotificationFeedbackGenerator().notificationOccurred(.error)
+    }
+}

--- a/F1App/F1App/F1AppApp.swift
+++ b/F1App/F1App/F1AppApp.swift
@@ -10,6 +10,7 @@ import SwiftUI
 @main
 struct F1AppApp: App {
     @State private var showSplash = true
+    @StateObject private var teamColorStore = TeamColorStore()
 
     var body: some Scene {
         WindowGroup {
@@ -24,6 +25,7 @@ struct F1AppApp: App {
                     .transition(.opacity)
                 }
             }
+            .environmentObject(teamColorStore)
         }
     }
 }

--- a/F1App/F1App/RaceDetailView.swift
+++ b/F1App/F1App/RaceDetailView.swift
@@ -31,12 +31,24 @@ struct RaceDetailView: View {
                     .frame(height: UIScreen.main.bounds.height / 2)
                     .padding()
             } else if selectedTab == 1 {
-                List(viewModel.strategySuggestions) { s in
-                    NavigationLink(destination: StrategyDetailView(suggestion: s)) {
-                        VStack(alignment: .leading) {
-                            Text(s.driver_name ?? "Driver \(s.driver_number ?? 0)").font(.headline)
-                            Text(s.advice).bold()
-                            Text(s.why).font(.caption)
+                VStack {
+                    if let message = viewModel.errorMessage {
+                        ErrorBanner(message: message)
+                            .padding()
+                    } else if viewModel.strategySuggestions.isEmpty {
+                        QueuedView()
+                            .shimmer()
+                            .padding()
+                    } else {
+                        ScrollView {
+                            LazyVStack(spacing: 16) {
+                                ForEach(viewModel.strategySuggestions) { s in
+                                    NavigationLink(destination: StrategyDetailView(suggestion: s)) {
+                                        StrategySuggestionCard(suggestion: s)
+                                    }
+                                }
+                            }
+                            .padding()
                         }
                     }
                 }

--- a/F1App/F1App/Services/TeamColorService.swift
+++ b/F1App/F1App/Services/TeamColorService.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+struct TeamColor: Codable {
+    let id: Int
+    let name: String
+    let primary: String
+    let secondary: String?
+}
+
+struct TeamColorsResponse: Codable {
+    let teams: [TeamColor]
+}
+
+final class TeamColorService {
+    func fetchColors() async throws -> [TeamColor] {
+        let url = API.url("/api/teams/colors")
+        let (data, _) = try await URLSession.shared.data(from: url)
+        let decoded = try JSONDecoder().decode(TeamColorsResponse.self, from: data)
+        return decoded.teams
+    }
+}

--- a/F1App/F1App/Stores/TeamColorStore.swift
+++ b/F1App/F1App/Stores/TeamColorStore.swift
@@ -1,0 +1,48 @@
+import SwiftUI
+
+@MainActor
+final class TeamColorStore: ObservableObject {
+    @Published private(set) var colors: [Int: TeamColor] = [:]
+    private let service = TeamColorService()
+    private let cacheKey = "team_colors_cache"
+
+    init() {
+        if let data = UserDefaults.standard.data(forKey: cacheKey),
+           let decoded = try? JSONDecoder().decode([Int: TeamColor].self, from: data) {
+            colors = decoded
+        }
+        Task { await refresh() }
+    }
+
+    func refresh() async {
+        do {
+            let fetched = try await service.fetchColors()
+            var dict: [Int: TeamColor] = [:]
+            for c in fetched { dict[c.id] = c }
+            colors = dict
+            if let data = try? JSONEncoder().encode(dict) {
+                UserDefaults.standard.set(data, forKey: cacheKey)
+            }
+        } catch {
+            // ignore errors for now
+        }
+    }
+
+    func color(forTeamId id: Int?) -> Color {
+        guard let id = id, let hex = colors[id]?.primary else { return AppColors.accentRed }
+        return Color(hex: hex)
+    }
+
+    func color(forTeamName name: String?) -> Color {
+        guard let name = name else { return AppColors.accentRed }
+        if let match = colors.values.first(where: { $0.name.lowercased() == name.lowercased() }) {
+            return Color(hex: match.primary)
+        }
+        return AppColors.accentRed
+    }
+
+    func color(forDriverNumber number: Int?) -> Color {
+        // Driver to team mapping not available yet
+        return AppColors.accentRed
+    }
+}

--- a/README_DESIGN.md
+++ b/README_DESIGN.md
@@ -1,0 +1,34 @@
+# Design System & Team Colors
+
+Acest document descrie noile componente vizuale și serviciul de culori pentru aplicația iOS **F1App**.
+
+## TeamColorStore
+- `TeamColorStore` este un `ObservableObject` care încarcă culorile echipelor prin endpoint-ul `/api/teams/colors`.
+- Culorile sunt memorate în `UserDefaults` și pot fi obținute prin:
+  - `color(forTeamId:)`
+  - `color(forTeamName:)`
+  - `color(forDriverNumber:)` (fallback la accent roșu dacă nu există mapare).
+- În `F1AppApp` store-ul este creat cu `@StateObject` și injectat cu `.environmentObject`.
+
+## Componente
+- **Card** – container cu fundal `AppColors.surface`, colțuri 20, stroke fin și shadow subtil.
+- **TeamChip** – capsulă colorată după echipă.
+- **DriverRow** – afișează poziția, numărul și numele pilotului cu culoarea echipei.
+- **StrategySuggestionCard** – card care combină `DriverRow` cu detaliile strategiei.
+- **StateViews** – include `QueuedView`, `EmptyStateView` și `ErrorBanner` pentru stări de încărcare/eroare.
+
+## Stiluri
+- Paletă: alb `#FFFFFF`, roșu `#E10600`, negru `#0A0A0A` cu suport Light/Dark.
+- Tipografie: `titleXL`, `titleL`, `bodyStyle`, `captionStyle` (SF Pro).
+- Shimmer: `.shimmer()` pentru stări de încărcare.
+- Animații: `.animation(.interpolatingSpring(stiffness: 220, damping: 28))` pe apariția cardurilor.
+
+## Utilizare
+```swift
+@EnvironmentObject var colorStore: TeamColorStore
+
+StrategySuggestionCard(suggestion: s)
+TeamChip(teamId: s.teamId, teamName: s.team)
+```
+
+Culorile sunt obținute din `TeamColorStore`; în lipsă se folosește roșul de accent.


### PR DESCRIPTION
## Summary
- add modern design system components and haptics
- fetch team colors from API with TeamColorStore and integrate into strategy UI
- expose `/api/teams/colors` endpoint in Laravel backend

## Testing
- `xcodebuild -list` *(fails: command not found)*
- `php artisan test` *(fails: vendor autoload missing)*

------
https://chatgpt.com/codex/tasks/task_e_68ae12ce48dc83238fa1bfe01d806655