### PR TITLE
Use team colors for strategy suggestions

### DIFF
--- a/F1App/F1App/Components/DriverRow.swift
+++ b/F1App/F1App/Components/DriverRow.swift
@@ -9,6 +9,7 @@ struct DriverRow: View {
     let driverName: String
     let teamName: String
     let trend: Int?
+    let teamColor: Color?
 
     var body: some View {
         HStack(spacing: Layout.Spacing.m) {
@@ -20,7 +21,7 @@ struct DriverRow: View {
             }
 
             Circle()
-                .fill(colorStore.color(forTeamName: teamName))
+                .fill(teamColor ?? colorStore.color(forTeamName: teamName))
                 .frame(width: 32, height: 32)
                 .overlay(
                     Text(driverNumber.map(String.init) ?? "")

--- a/F1App/F1App/Components/StrategySuggestionCard.swift
+++ b/F1App/F1App/Components/StrategySuggestionCard.swift
@@ -1,8 +1,8 @@
 import SwiftUI
 
 struct StrategySuggestionCard: View {
-    @EnvironmentObject var colorStore: TeamColorStore
     let suggestion: StrategySuggestion
+    let driver: DriverInfo?
 
     var body: some View {
         Card {
@@ -10,9 +10,10 @@ struct StrategySuggestionCard: View {
                 DriverRow(
                     position: suggestion.position,
                     driverNumber: suggestion.driver_number,
-                    driverName: suggestion.driver_name ?? "Driver \(suggestion.driver_number ?? 0)",
-                    teamName: suggestion.team ?? "",
-                    trend: nil
+                    driverName: driver?.full_name ?? (suggestion.driver_name ?? "Driver \(suggestion.driver_number ?? 0)"),
+                    teamName: driver?.team_name ?? (suggestion.team ?? ""),
+                    trend: nil,
+                    teamColor: driver?.team_color.map(Color.init(hex:))
                 )
 
                 Text(suggestion.advice)

--- a/F1App/F1App/RaceDetailView.swift
+++ b/F1App/F1App/RaceDetailView.swift
@@ -43,8 +43,9 @@ struct RaceDetailView: View {
                         ScrollView {
                             LazyVStack(spacing: Layout.Spacing.l) {
                                 ForEach(viewModel.strategySuggestions) { s in
-                                    NavigationLink(destination: StrategyDetailView(suggestion: s)) {
-                                        StrategySuggestionCard(suggestion: s)
+                                    let driver = viewModel.drivers.first { $0.driver_number == s.driver_number }
+                                    NavigationLink(destination: StrategyDetailView(suggestion: s, driver: driver)) {
+                                        StrategySuggestionCard(suggestion: s, driver: driver)
                                     }
                                 }
                             }

--- a/F1App/F1App/StrategyDetailView.swift
+++ b/F1App/F1App/StrategyDetailView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct StrategyDetailView: View {
     let suggestion: StrategySuggestion
+    let driver: DriverInfo?
 
     var body: some View {
         ScrollView {
@@ -10,9 +11,10 @@ struct StrategyDetailView: View {
                     DriverRow(
                         position: suggestion.position,
                         driverNumber: suggestion.driver_number,
-                        driverName: suggestion.driver_name ?? "Driver \(suggestion.driver_number ?? 0)",
-                        teamName: suggestion.team ?? "",
-                        trend: nil
+                        driverName: driver?.full_name ?? (suggestion.driver_name ?? "Driver \(suggestion.driver_number ?? 0)"),
+                        teamName: driver?.team_name ?? (suggestion.team ?? ""),
+                        trend: nil,
+                        teamColor: driver?.team_color.map(Color.init(hex:))
                     )
 
                     Text("Advice")
@@ -38,10 +40,16 @@ struct StrategyDetailView: View {
 }
 
 #Preview {
-    StrategyDetailView(suggestion: StrategySuggestion(driver_number: 1,
-                                                     driver_name: "Example Driver",
-                                                     team: "Example Team",
-                                                     position: 1,
-                                                     advice: "Pit now",
-                                                     why: "Fresh tires needed"))
+    StrategyDetailView(
+        suggestion: StrategySuggestion(driver_number: 1,
+                                      driver_name: "Example Driver",
+                                      team: "Example Team",
+                                      position: 1,
+                                      advice: "Pit now",
+                                      why: "Fresh tires needed"),
+        driver: DriverInfo(driver_number: 1,
+                           full_name: "Example Driver",
+                           team_color: "FF0000",
+                           team_name: "Example Team")
+    )
 }


### PR DESCRIPTION
## Summary
- display driver number circles in strategy views using each driver's team color
- pass driver data into strategy suggestion components
- allow DriverRow to accept an explicit team color

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild test -scheme F1App -destination 'platform=iOS Simulator,name=iPhone 14'` *(fails: command not found: xcodebuild)*

------
https://chatgpt.com/codex/tasks/task_e_68ae1e58f03c832388014f0d221dcabf