### PR TITLE
feat: add race summary and circuit tabs

### DIFF
--- a/F1App/F1App/Design/Components/Chip.swift
+++ b/F1App/F1App/Design/Components/Chip.swift
@@ -1,0 +1,25 @@
+import SwiftUI
+
+struct Chip: View {
+    var text: String
+    var systemImage: String?
+    var body: some View {
+        HStack(spacing: Layout.Spacing.xs) {
+            if let systemImage {
+                Image(systemName: systemImage)
+            }
+            Text(text)
+                .font(.caption)
+        }
+        .padding(.horizontal, Layout.Spacing.m)
+        .padding(.vertical, Layout.Spacing.xs)
+        .background(AppColors.surface)
+        .clipShape(Capsule())
+    }
+}
+
+#Preview {
+    Chip(text: "Finalizată", systemImage: "checkmark")
+        .padding()
+        .background(AppColors.bg)
+}

--- a/F1App/F1App/Design/Components/StatPill.swift
+++ b/F1App/F1App/Design/Components/StatPill.swift
@@ -1,0 +1,34 @@
+import SwiftUI
+
+struct StatPill: View {
+    var icon: String
+    var title: String
+    var value: String
+
+    var body: some View {
+        VStack(spacing: Layout.Spacing.s) {
+            Image(systemName: icon)
+                .font(.title2)
+            VStack(spacing: Layout.Spacing.xs) {
+                Text(value)
+                    .font(.headline)
+                Text(title)
+                    .font(.caption)
+                    .foregroundStyle(AppColors.textSec)
+            }
+        }
+        .frame(maxWidth: .infinity)
+        .padding(Layout.Spacing.m)
+        .background(AppColors.surface)
+        .clipShape(RoundedRectangle(cornerRadius: 12))
+    }
+}
+
+#Preview {
+    HStack {
+        StatPill(icon: "timer", title: "Fastest", value: "1:23.456")
+        StatPill(icon: "flag.checkered", title: "Laps", value: "58")
+    }
+    .padding()
+    .background(AppColors.bg)
+}

--- a/F1App/F1App/Views/Race/Components/RaceSummaryHeader.swift
+++ b/F1App/F1App/Views/Race/Components/RaceSummaryHeader.swift
@@ -1,0 +1,56 @@
+import SwiftUI
+
+struct RaceSummaryHeader: View {
+    var race: RaceDetailData
+    @EnvironmentObject var colorStore: TeamColorStore
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Layout.Spacing.l) {
+            HStack(spacing: Layout.Spacing.s) {
+                Chip(text: "Finalizată", systemImage: "checkmark")
+                Chip(text: "Runda \(race.round)")
+                Chip(text: race.date.formatted(date: .numeric, time: .omitted))
+                Spacer()
+                Button(action: {}) { Image(systemName: "square.and.arrow.up") }
+                Button(action: {}) { Image(systemName: "star") }
+            }
+            .foregroundStyle(AppColors.textPri)
+
+            HStack(spacing: Layout.Spacing.m) {
+                podiumView(position: "P1", driver: race.p1)
+                podiumView(position: "P2", driver: race.p2)
+                podiumView(position: "P3", driver: race.p3)
+            }
+
+            HStack(spacing: Layout.Spacing.m) {
+                StatPill(icon: "timer", title: "Fastest", value: race.fastestLap.time)
+                StatPill(icon: "car.side", title: "SC/VSC", value: "\(race.scCount)/\(race.vscCount)")
+                StatPill(icon: "wrench.and.screwdriver", title: "Pit Δ", value: race.pitDelta)
+                StatPill(icon: race.weatherIcon, title: "Vreme", value: race.weatherTemp)
+            }
+        }
+        .padding()
+        .background(AppColors.surface)
+    }
+
+    func podiumView(position: String, driver: DriverResultData) -> some View {
+        HStack(spacing: Layout.Spacing.s) {
+            Circle()
+                .fill(colorStore.color(forTeamName: driver.team))
+                .frame(width: 24, height: 24)
+            VStack(alignment: .leading, spacing: 2) {
+                Text("\(position) • \(driver.name)")
+                    .font(.headline)
+                Text(driver.team)
+                    .font(.caption)
+                    .foregroundStyle(AppColors.textSec)
+            }
+        }
+    }
+}
+
+#Preview {
+    RaceSummaryHeader(race: .sample)
+        .environmentObject(TeamColorStore(service: PreviewColorService()))
+        .background(AppColors.bg)
+}

--- a/F1App/F1App/Views/Race/RaceScreen.swift
+++ b/F1App/F1App/Views/Race/RaceScreen.swift
@@ -1,0 +1,174 @@
+import SwiftUI
+
+struct RaceScreen: View {
+    var race: RaceDetailData
+    @State private var selectedTab: Tab = .summary
+
+    enum Tab: Int, CaseIterable {
+        case summary, results, strategy, circuit, history
+
+        var title: String {
+            switch self {
+            case .summary: return "Rezumat"
+            case .results: return "Rezultate"
+            case .strategy: return "Strategie"
+            case .circuit: return "Circuit"
+            case .history: return "Istoric"
+            }
+        }
+    }
+
+    var body: some View {
+        ScrollView {
+            VStack(spacing: 0) {
+                // Content for selected tab
+                Group {
+                    switch selectedTab {
+                    case .summary:
+                        SummaryTab(race: race)
+                    case .results:
+                        ResultsTab(results: race.results)
+                    case .strategy:
+                        StrategyTab(drivers: race.drivers)
+                    case .circuit:
+                        CircuitTab(race: race)
+                    case .history:
+                        HistoryTab(history: race.history)
+                    }
+                }
+                .padding(.top, Layout.Spacing.xl)
+            }
+        }
+        .safeAreaInset(edge: .top) {
+            VStack(spacing: Layout.Spacing.m) {
+                RaceSummaryHeader(race: race)
+                Picker("Tab", selection: $selectedTab) {
+                    ForEach(Tab.allCases, id: \.self) { tab in
+                        Text(tab.title).tag(tab)
+                    }
+                }
+                .pickerStyle(.segmented)
+                .padding(.horizontal)
+            }
+            .background(AppColors.bg)
+        }
+        .navigationTitle(race.name)
+        .navigationBarTitleDisplayMode(.inline)
+    }
+}
+
+// MARK: - Sample Data Models
+
+struct RaceDetailData {
+    var name: String
+    var round: Int
+    var date: Date
+    var coordinates: String? = nil
+    var p1: DriverResultData
+    var p2: DriverResultData
+    var p3: DriverResultData
+    var fastestLap: (time: String, driver: String)
+    var scCount: Int
+    var vscCount: Int
+    var pitDelta: String
+    var weatherIcon: String
+    var weatherTemp: String
+    var results: [DriverResultData]
+    var drivers: [DriverStrategyData]
+    var history: [PastRaceData]
+    var trackFacts: [TrackFactData]
+}
+
+struct DriverResultData: Identifiable {
+    let id = UUID()
+    var name: String
+    var team: String
+    var points: Int = 0
+    var gapToLeader: String? = nil
+    var lastCompound: String? = nil
+    var dnf: Bool = false
+}
+
+struct DriverStrategyData: Identifiable {
+    let id = UUID()
+    var name: String
+    var team: String
+    var stints: [StintData]
+}
+
+struct StintData: Identifiable {
+    let id = UUID()
+    var startLap: Int
+    var endLap: Int
+    var compound: String
+}
+
+struct PastRaceData: Identifiable {
+    let id = UUID()
+    var year: String
+    var winner: String
+    var poleToWin: String
+    var pits: String
+    var scRate: String
+}
+
+struct TrackFactData: Identifiable {
+    let id = UUID()
+    var label: String
+    var value: String
+}
+
+extension RaceDetailData {
+    static let sample: RaceDetailData = {
+        let p1 = DriverResultData(name: "Max Verstappen", team: "Red Bull")
+        let p2 = DriverResultData(name: "Sergio Perez", team: "Red Bull")
+        let p3 = DriverResultData(name: "Charles Leclerc", team: "Ferrari")
+        let results = [
+            DriverResultData(name: "Max Verstappen", team: "Red Bull", points: 25, gapToLeader: "Leader", lastCompound: "S"),
+            DriverResultData(name: "Sergio Perez", team: "Red Bull", points: 18, gapToLeader: "+5.0s", lastCompound: "S"),
+            DriverResultData(name: "Charles Leclerc", team: "Ferrari", points: 15, gapToLeader: "+10.2s", lastCompound: "M")
+        ]
+        let drivers = [
+            DriverStrategyData(name: "Max Verstappen", team: "Red Bull", stints: [
+                StintData(startLap: 1, endLap: 20, compound: "S"),
+                StintData(startLap: 21, endLap: 40, compound: "M")
+            ])
+        ]
+        let history = [
+            PastRaceData(year: "2023", winner: "Max Verstappen", poleToWin: "80%", pits: "1-2", scRate: "40%"),
+            PastRaceData(year: "2022", winner: "Charles Leclerc", poleToWin: "60%", pits: "2", scRate: "30%"),
+            PastRaceData(year: "2021", winner: "Lewis Hamilton", poleToWin: "70%", pits: "2", scRate: "50%")
+        ]
+        let facts = [
+            TrackFactData(label: "Lungime", value: "5.9 km"),
+            TrackFactData(label: "Ture", value: "58"),
+            TrackFactData(label: "Viraje", value: "16"),
+            TrackFactData(label: "Lap record", value: "1:21.046"),
+            TrackFactData(label: "Pierdere pit", value: "23s"),
+            TrackFactData(label: "Prob. SC", value: "40%")
+        ]
+        return RaceDetailData(
+            name: "Imola", round: 6, date: Date(),
+            coordinates: nil,
+            p1: p1, p2: p2, p3: p3,
+            fastestLap: ("1:23.456", "Max Verstappen"),
+            scCount: 1, vscCount: 1, pitDelta: "23.1s",
+            weatherIcon: "sun.max", weatherTemp: "24°C",
+            results: results, drivers: drivers, history: history, trackFacts: facts
+        )
+    }()
+}
+
+struct PreviewColorService: TeamColorProviding {
+    func fetchColors() async throws -> [TeamColor] {
+        [TeamColor(id: 1, name: "Red Bull", primary: "#3671C6", secondary: nil),
+         TeamColor(id: 2, name: "Ferrari", primary: "#E10600", secondary: nil)]
+    }
+}
+
+#Preview {
+    NavigationView {
+        RaceScreen(race: .sample)
+            .environmentObject(TeamColorStore(service: PreviewColorService()))
+    }
+}

--- a/F1App/F1App/Views/Race/Tabs/CircuitTab.swift
+++ b/F1App/F1App/Views/Race/Tabs/CircuitTab.swift
@@ -1,0 +1,42 @@
+import SwiftUI
+
+struct CircuitTab: View {
+    var race: RaceDetailData
+    @StateObject private var viewModel = HistoricalRaceViewModel()
+
+    var body: some View {
+        VStack(spacing: Layout.Spacing.l) {
+            if let coords = race.coordinates {
+                CircuitView(coordinatesJSON: coords, viewModel: viewModel)
+                    .frame(height: 250)
+            } else {
+                RoundedRectangle(cornerRadius: 12)
+                    .fill(AppColors.surface)
+                    .frame(height: 250)
+                    .overlay(Text("Harta indisponibilă"))
+            }
+
+            LazyVGrid(columns: Array(repeating: GridItem(.flexible(), spacing: Layout.Spacing.l), count: 2), spacing: Layout.Spacing.l) {
+                ForEach(race.trackFacts) { fact in
+                    VStack(alignment: .leading, spacing: Layout.Spacing.xs) {
+                        Text(fact.label)
+                            .font(.caption)
+                            .foregroundStyle(AppColors.textSec)
+                        Text(fact.value)
+                            .font(.headline)
+                    }
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding()
+                    .background(AppColors.surface)
+                    .clipShape(RoundedRectangle(cornerRadius: 12))
+                }
+            }
+        }
+        .padding()
+    }
+}
+
+#Preview {
+    CircuitTab(race: .sample)
+        .background(AppColors.bg)
+}

--- a/F1App/F1App/Views/Race/Tabs/HistoryTab.swift
+++ b/F1App/F1App/Views/Race/Tabs/HistoryTab.swift
@@ -1,0 +1,43 @@
+import SwiftUI
+
+struct HistoryTab: View {
+    var history: [PastRaceData]
+
+    var body: some View {
+        ScrollView {
+            VStack(spacing: Layout.Spacing.m) {
+                ForEach(history) { race in
+                    HStack {
+                        VStack(alignment: .leading, spacing: Layout.Spacing.xs) {
+                            Text(race.year)
+                                .font(.headline)
+                            Text("Câștigător: \(race.winner)")
+                                .font(.caption)
+                                .foregroundStyle(AppColors.textSec)
+                            Text("Pole→Win: \(race.poleToWin)")
+                                .font(.caption)
+                                .foregroundStyle(AppColors.textSec)
+                        }
+                        Spacer()
+                        VStack(alignment: .trailing, spacing: Layout.Spacing.xs) {
+                            Text(race.pits)
+                                .font(.caption)
+                            Text(race.scRate)
+                                .font(.caption)
+                        }
+                    }
+                    .padding()
+                    .frame(maxWidth: .infinity)
+                    .background(AppColors.surface)
+                    .clipShape(RoundedRectangle(cornerRadius: 12))
+                }
+            }
+            .padding()
+        }
+    }
+}
+
+#Preview {
+    HistoryTab(history: RaceDetailData.sample.history)
+        .background(AppColors.bg)
+}

--- a/F1App/F1App/Views/Race/Tabs/ResultRow.swift
+++ b/F1App/F1App/Views/Race/Tabs/ResultRow.swift
@@ -1,0 +1,46 @@
+import SwiftUI
+
+struct ResultRow: View {
+    var position: Int
+    var result: DriverResultData
+    @EnvironmentObject var colorStore: TeamColorStore
+
+    var body: some View {
+        HStack(spacing: Layout.Spacing.m) {
+            Text("\(position)")
+                .frame(width: 28)
+                .font(.headline)
+            VStack(alignment: .leading) {
+                Text(result.name)
+                    .font(.headline)
+                Text(result.dnf ? "DNF" : (result.gapToLeader ?? ""))
+                    .font(.caption)
+                    .foregroundStyle(result.dnf ? Color.red : AppColors.textSec)
+            }
+            Spacer()
+            VStack(alignment: .trailing) {
+                Text("\(result.points)")
+                    .font(.headline)
+                if let compound = result.lastCompound {
+                    Text(compound)
+                        .font(.caption)
+                        .foregroundStyle(AppColors.textSec)
+                }
+            }
+        }
+        .padding(.vertical, Layout.Spacing.s)
+        .padding(.leading, Layout.Spacing.m)
+        .background(
+            colorStore.color(forTeamName: result.team)
+                .frame(width: 4)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        )
+        .accessibilityLabel("Poziția \(position), \(result.name), \(result.points) puncte")
+    }
+}
+
+#Preview {
+    ResultRow(position: 1, result: RaceDetailData.sample.results[0])
+        .environmentObject(TeamColorStore(service: PreviewColorService()))
+        .padding()
+}

--- a/F1App/F1App/Views/Race/Tabs/ResultsTab.swift
+++ b/F1App/F1App/Views/Race/Tabs/ResultsTab.swift
@@ -1,0 +1,45 @@
+import SwiftUI
+
+struct ResultsTab: View {
+    var results: [DriverResultData]
+    @EnvironmentObject var colorStore: TeamColorStore
+    @State private var filter: Filter = .top10
+
+    enum Filter: String, CaseIterable, Identifiable {
+        case top10 = "Top 10"
+        case all = "Toți"
+        case mine = "Echipa mea"
+        var id: String { rawValue }
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Layout.Spacing.m) {
+            HStack {
+                ForEach(Filter.allCases) { f in
+                    Text(f.rawValue)
+                        .font(.caption)
+                        .padding(.horizontal, Layout.Spacing.m)
+                        .padding(.vertical, Layout.Spacing.xs)
+                        .background(filter == f ? AppColors.accent.opacity(0.2) : AppColors.surface)
+                        .clipShape(Capsule())
+                        .onTapGesture { withAnimation { filter = f } }
+                }
+            }
+            .padding(.horizontal)
+
+            ScrollView {
+                LazyVStack(spacing: Layout.Spacing.s) {
+                    ForEach(Array(results.enumerated()), id: \.0) { index, result in
+                        ResultRow(position: index + 1, result: result)
+                    }
+                }
+                .padding(.horizontal)
+            }
+        }
+    }
+}
+
+#Preview {
+    ResultsTab(results: RaceDetailData.sample.results)
+        .environmentObject(TeamColorStore(service: PreviewColorService()))
+}

--- a/F1App/F1App/Views/Race/Tabs/StintBar.swift
+++ b/F1App/F1App/Views/Race/Tabs/StintBar.swift
@@ -1,0 +1,34 @@
+import SwiftUI
+
+struct StintBar: View {
+    var stints: [StintData]
+
+    func color(for compound: String) -> Color {
+        switch compound.uppercased() {
+        case "S": return .red
+        case "M": return .yellow
+        case "H": return .gray
+        default: return .blue
+        }
+    }
+
+    var body: some View {
+        GeometryReader { geo in
+            let totalLaps = stints.map { $0.endLap - $0.startLap + 1 }.reduce(0, +)
+            HStack(spacing: 0) {
+                ForEach(stints) { stint in
+                    let laps = stint.endLap - stint.startLap + 1
+                    color(for: stint.compound)
+                        .frame(width: geo.size.width * CGFloat(laps) / CGFloat(totalLaps), height: 20)
+                }
+            }
+        }
+        .frame(height: 20)
+        .clipShape(RoundedRectangle(cornerRadius: 10))
+    }
+}
+
+#Preview {
+    StintBar(stints: RaceDetailData.sample.drivers[0].stints)
+        .padding()
+}

--- a/F1App/F1App/Views/Race/Tabs/StrategyTab.swift
+++ b/F1App/F1App/Views/Race/Tabs/StrategyTab.swift
@@ -1,0 +1,25 @@
+import SwiftUI
+
+struct StrategyTab: View {
+    var drivers: [DriverStrategyData]
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: Layout.Spacing.m) {
+                ForEach(drivers) { driver in
+                    VStack(alignment: .leading, spacing: Layout.Spacing.s) {
+                        Text(driver.name)
+                            .font(.headline)
+                        StintBar(stints: driver.stints)
+                    }
+                }
+            }
+            .padding()
+        }
+    }
+}
+
+#Preview {
+    StrategyTab(drivers: RaceDetailData.sample.drivers)
+        .background(AppColors.bg)
+}

--- a/F1App/F1App/Views/Race/Tabs/SummaryTab.swift
+++ b/F1App/F1App/Views/Race/Tabs/SummaryTab.swift
@@ -1,0 +1,54 @@
+import SwiftUI
+
+struct SummaryTab: View {
+    var race: RaceDetailData
+
+    var body: some View {
+        VStack(spacing: Layout.Spacing.l) {
+            CardView(title: "Momente cheie") {
+                Text("SC la turul 23, pit decisiv P2")
+                    .font(.body)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+            CardView(title: "Pace & gaps") {
+                RoundedRectangle(cornerRadius: 8)
+                    .fill(AppColors.stroke)
+                    .frame(height: 80)
+            }
+            CardView(title: "Anvelope folosite") {
+                HStack(spacing: Layout.Spacing.s) {
+                    Capsule().fill(Color.red).frame(width: 80, height: 20)
+                    Capsule().fill(Color.yellow).frame(width: 60, height: 20)
+                    Capsule().fill(Color.gray).frame(width: 40, height: 20)
+                }
+            }
+            CardView(title: "Evoluția pozițiilor") {
+                RoundedRectangle(cornerRadius: 8)
+                    .stroke(AppColors.stroke, lineWidth: 2)
+                    .frame(height: 120)
+            }
+        }
+        .padding()
+    }
+}
+
+struct CardView<Content: View>: View {
+    var title: String
+    @ViewBuilder var content: Content
+    var body: some View {
+        VStack(alignment: .leading, spacing: Layout.Spacing.m) {
+            Text(title)
+                .font(.title2)
+            content
+        }
+        .padding()
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(AppColors.surface)
+        .clipShape(RoundedRectangle(cornerRadius: 12))
+    }
+}
+
+#Preview {
+    SummaryTab(race: .sample)
+        .background(AppColors.bg)
+}


### PR DESCRIPTION
## Summary
- implement modular RaceScreen with sticky summary header and segmented tabs
- add reusable Chip and StatPill components
- introduce Circuit tab with track map and track facts grid

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68ae28c074d0832383c22e5aa04ee20b