### PR TITLE
Use OpenF1 API directly for results and telemetry

### DIFF
--- a/F1App/F1App/API.swift
+++ b/F1App/F1App/API.swift
@@ -6,6 +6,8 @@ let baseURL = URL(string: "http://127.0.0.1:8000")!
 let baseURL = URL(string: "http://<IP_LAN_MAC>:8000")! // ex. 192.168.1.23
 #endif
 
+let openF1BaseURL = "https://api.openf1.org/v1"
+
 enum API {
     #if targetEnvironment(simulator)
     static let baseURL = URL(string: (ProcessInfo.processInfo.environment["API_BASE"] ?? "http://127.0.0.1:8000"))!

--- a/F1App/F1App/HistoricalRaceViewModel.swift
+++ b/F1App/F1App/HistoricalRaceViewModel.swift
@@ -278,7 +278,7 @@ class HistoricalRaceViewModel: ObservableObject {
     }
 
     private func fetchDrivers(sessionKey: Int) {
-        var comps = URLComponents(string: "\(API.base)/api/openf1/drivers")!
+        var comps = URLComponents(string: "\(openF1BaseURL)/drivers")!
         comps.queryItems = [URLQueryItem(name: "session_key", value: String(sessionKey))]
         guard let url = comps.url else { return }
         URLSession.shared.dataTask(with: url) { data, resp, error in
@@ -302,7 +302,7 @@ class HistoricalRaceViewModel: ObservableObject {
     }
 
     private func fetchRaceControl(sessionKey: Int) {
-        var comps = URLComponents(string: "\(API.base)/api/openf1/race_control")!
+        var comps = URLComponents(string: "\(openF1BaseURL)/race_control")!
         comps.queryItems = [URLQueryItem(name: "session_key", value: String(sessionKey))]
         guard let url = comps.url else { return }
         URLSession.shared.dataTask(with: url) { data, resp, error in
@@ -338,7 +338,7 @@ class HistoricalRaceViewModel: ObservableObject {
     }
 
     private func fetchOvertakes(sessionKey: Int) {
-        var comps = URLComponents(string: "\(API.base)/api/openf1/overtakes")!
+        var comps = URLComponents(string: "\(openF1BaseURL)/overtakes")!
         comps.queryItems = [URLQueryItem(name: "session_key", value: String(sessionKey))]
         guard let url = comps.url else { return }
         URLSession.shared.dataTask(with: url) { data, resp, error in
@@ -402,7 +402,7 @@ class HistoricalRaceViewModel: ObservableObject {
                                   endStr: String,
                                   offset: Int,
                                   accumulated: [LocationPoint]) {
-            var comps = URLComponents(string: "\(API.base)/api/openf1/location")!
+            var comps = URLComponents(string: "\(openF1BaseURL)/location")!
             comps.queryItems = [
                 URLQueryItem(name: "session_key", value: String(sessionKey)),
                 URLQueryItem(name: "driver_number", value: String(driver.driver_number)),
@@ -673,7 +673,7 @@ class HistoricalRaceViewModel: ObservableObject {
                     return
                 }
                 let sk = session.session_key
-                var driversComps = URLComponents(string: "\(API.base)/api/openf1/drivers")!
+                var driversComps = URLComponents(string: "\(openF1BaseURL)/drivers")!
                 driversComps.queryItems = [URLQueryItem(name: "session_key", value: String(sk)), URLQueryItem(name: "limit", value: "5")]
                 let driversURL = driversComps.url!
                 URLSession.shared.dataTask(with: driversURL) { data, resp, err in
@@ -683,7 +683,7 @@ class HistoricalRaceViewModel: ObservableObject {
                         return
                     }
                     let countDrivers = dr.data.count
-                    var locURLC = URLComponents(string: "\(API.base)/api/openf1/location")!
+                    var locURLC = URLComponents(string: "\(openF1BaseURL)/location")!
                     locURLC.queryItems = [
                         URLQueryItem(name: "session_key", value: String(sk)),
                         URLQueryItem(name: "order_by", value: "date"),

--- a/F1App/F1App/RaceResultsView.swift
+++ b/F1App/F1App/RaceResultsView.swift
@@ -43,7 +43,7 @@ struct RaceResultsView: View {
     }
 
     private func fetchResults(sessionKey: Int) {
-        var comps = URLComponents(string: "\(API.base)/api/openf1/session_result")!
+        var comps = URLComponents(string: "\(openF1BaseURL)/session_result")!
         comps.queryItems = [
             URLQueryItem(name: "session_key", value: String(sessionKey)),
             URLQueryItem(name: "order_by", value: "position")


### PR DESCRIPTION
## Summary
- add `openF1BaseURL` constant and use OpenF1 endpoints directly
- fetch results, drivers, race control, overtakes and locations from `api.openf1.org`

## Testing
- `swift build` *(fails: Could not find Package.swift)*
- `curl -s 'https://api.openf1.org/v1/sessions?meeting_key=1220' | head -n 40`
- `curl -s 'https://api.openf1.org/v1/drivers?meeting_key=1220' | head -c 200`


------
https://chatgpt.com/codex/tasks/task_e_68ae388633b08323be35b312bec5d107