### PR TITLE
Fix race results fetching via correct OpenF1 endpoints

### DIFF
--- a/F1App/F1App/RaceDetailView.swift
+++ b/F1App/F1App/RaceDetailView.swift
@@ -28,7 +28,7 @@ struct RaceDetailView: View {
 
             if selectedTab == 0 {
                 if race.status.lowercased() == "finished" {
-                    RaceResultsView(viewModel: viewModel)
+                    RaceResultsView(race: race, viewModel: viewModel)
                         .padding()
                 } else {
                     CircuitView(coordinatesJSON: race.coordinates, viewModel: viewModel)


### PR DESCRIPTION
## Summary
- derive race session key from OpenF1 meetings and sessions endpoints
- fetch race results with the obtained session key
- pass selected race into `RaceResultsView`

## Testing
- `swiftc -typecheck F1App/F1App/RaceResultsView.swift F1App/F1App/RaceDetailView.swift` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_68ae3c0743d48323a20b603ed8a2850b