### PR TITLE
Stop filtering session results by max session_key

### DIFF
--- a/F1App/F1App/RaceResultsView.swift
+++ b/F1App/F1App/RaceResultsView.swift
@@ -69,12 +69,8 @@ struct RaceResultsView: View {
             URLSession.shared.dataTask(with: resultsURL) { data, _, _ in
                 guard
                     let data = data,
-                    var response = try? JSONDecoder().decode([SessionResultEntry].self, from: data)
+                    let response = try? JSONDecoder().decode([SessionResultEntry].self, from: data)
                 else { return }
-
-                if let raceSessionKey = response.compactMap({ $0.session_key }).max() {
-                    response = response.filter { $0.session_key == raceSessionKey }
-                }
 
                 DispatchQueue.main.async { self.results = response }
             }.resume()


### PR DESCRIPTION
## Summary
- Remove logic that attempted to filter session results to the session with the maximum `session_key`

## Testing
- `swift build` *(fails: Could not find Package.swift)*
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68ae49004b788323b14b0c21957f138d