### PR TITLE
Handle finished race statuses and refine result queries

### DIFF
--- a/API/F1_API/app/Http/Controllers/RaceController.php
+++ b/API/F1_API/app/Http/Controllers/RaceController.php
@@ -40,10 +40,14 @@ class RaceController extends Controller
     {
         $now = Carbon::now();
         $raceStart = Carbon::parse($race->date);
+        $raceEnd = $raceStart->copy()->addHours(4);
 
-        if (!in_array(strtolower($race->status), ['finished', 'cancelled']) &&
-            $now->between($raceStart, $raceStart->copy()->addHours(4))) {
-            $race->status = 'In Progress';
+        if (!in_array(strtolower($race->status), ['finished', 'cancelled'])) {
+            if ($now->between($raceStart, $raceEnd)) {
+                $race->status = 'In Progress';
+            } elseif ($now->greaterThan($raceEnd)) {
+                $race->status = 'Finished';
+            }
         }
 
         return $race;

--- a/F1App/F1App/RaceResultsView.swift
+++ b/F1App/F1App/RaceResultsView.swift
@@ -42,7 +42,7 @@ struct RaceResultsView: View {
         guard
             let circuitId = race.circuit_id,
             let circuitKey = Int(circuitId),
-            let yearInt = Int(viewModel.year)
+            let yearInt = Int(race.date.prefix(4))
         else { return }
 
         var meetingComps = URLComponents(string: "\(openF1BaseURL)/meetings")!
@@ -62,7 +62,8 @@ struct RaceResultsView: View {
             var resultsComps = URLComponents(string: "\(openF1BaseURL)/session_result")!
             resultsComps.queryItems = [
                 URLQueryItem(name: "meeting_key", value: String(meetingKey)),
-                URLQueryItem(name: "order_by", value: "position")
+                URLQueryItem(name: "order_by", value: "position"),
+                URLQueryItem(name: "session_type", value: "Race")
             ]
             guard let resultsURL = resultsComps.url else { return }
 


### PR DESCRIPTION
## Summary
- derive race year from race date and filter session results for the race session
- auto-mark races as Finished once the end time has passed

## Testing
- `swift build` *(fails: Could not find Package.swift in this directory or any of its parent directories)*
- `php artisan test` *(fails: SQLSTATE[HY000] [2002] Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68ae4bafa2988323ae2e041037933b1c