### PR TITLE
Remove redundant order_by parameter from session results request

### DIFF
--- a/F1App/F1App/RaceResultsView.swift
+++ b/F1App/F1App/RaceResultsView.swift
@@ -102,8 +102,7 @@ struct RaceResultsView: View {
     private func fetchSessionResults(meetingKey: Int) async throws -> [SessionResultEntry] {
         var resultsComps = URLComponents(string: "\(openF1BaseURL)/session_result")!
         resultsComps.queryItems = [
-            URLQueryItem(name: "meeting_key", value: String(meetingKey)),
-            URLQueryItem(name: "order_by", value: "position")
+            URLQueryItem(name: "meeting_key", value: String(meetingKey))
         ]
         guard let resultsURL = resultsComps.url else { throw URLError(.badURL) }
         print("🌐 session_result URL:", resultsURL.absoluteString)


### PR DESCRIPTION
## Summary
- remove order_by query item from session_result request since results are already ordered

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68af60cc406c832393ef7a4530f6259f