### PR TITLE
Remove order_by parameter from session result API call

### DIFF
--- a/F1App/F1App/RaceResultsView.swift
+++ b/F1App/F1App/RaceResultsView.swift
@@ -158,8 +158,7 @@ struct RaceResultsView: View {
     private func fetchSessionResults(sessionKey: Int) async throws -> [SessionResultEntry] {
         var comps = URLComponents(string: "\(openF1BaseURL)/session_result")!
         comps.queryItems = [
-            .init(name: "session_key", value: String(sessionKey)),
-            .init(name: "order_by", value: "position")
+            .init(name: "session_key", value: String(sessionKey))
         ]
         let url = comps.url!
         print("🌐 session_result URL:", url.absoluteString)


### PR DESCRIPTION
## Summary
- drop `order_by=position` when requesting `session_result` from OpenF1

## Testing
- `swift build` *(fails: Could not find Package.swift)*
- `xcodebuild -project F1App.xcodeproj -scheme F1App -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 14'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af81a1deb88323a84b6369ffc87884