### PR TITLE
Use local Laravel API for historical race data

### DIFF
--- a/F1App/F1App/API.swift
+++ b/F1App/F1App/API.swift
@@ -6,8 +6,6 @@ let baseURL = URL(string: "http://127.0.0.1:8000")!
 let baseURL = URL(string: "http://<IP_LAN_MAC>:8000")! // ex. 192.168.1.23
 #endif
 
-let openF1BaseURL = "https://api.openf1.org/v1"
-
 enum API {
     #if targetEnvironment(simulator)
     static let baseURL = URL(string: (ProcessInfo.processInfo.environment["API_BASE"] ?? "http://127.0.0.1:8000"))!
@@ -30,7 +28,7 @@ enum API {
     }
 }
 
-
+let openF1BaseURL = "\(API.base)/api/openf1"
 
 func getJSON<T: Decodable>(_ path: String, query: [String:String]? = nil) async throws -> T {
     let url = API.url(path, query: query)

--- a/F1App/F1App/HistoricalRaceViewModel.swift
+++ b/F1App/F1App/HistoricalRaceViewModel.swift
@@ -216,7 +216,7 @@ class HistoricalRaceViewModel: ObservableObject {
     }
 
     private func resolveSession(year: Int, meetingKey: Int?, circuitKey: Int?) {
-        var comps = URLComponents(string: "\(API.base)/api/live/resolve")!
+        var comps = URLComponents(string: "\(API.base)/api/historical/resolve")!
         var items = [
             URLQueryItem(name: "year", value: String(year))
         ]
@@ -229,7 +229,7 @@ class HistoricalRaceViewModel: ObservableObject {
 
         let url = comps.url!
         URLSession.shared.dataTask(with: url) { data, resp, error in
-            self.log("GET /live/resolve", "url=\(url)\nerr=\(String(describing: error)) status=\((resp as? HTTPURLResponse)?.statusCode ?? -1)\n\(self.previewBody(data))")
+            self.log("GET /historical/resolve", "url=\(url)\nerr=\(String(describing: error)) status=\((resp as? HTTPURLResponse)?.statusCode ?? -1)\n\(self.previewBody(data))")
             if let http = resp as? HTTPURLResponse, http.statusCode != 200 {
                 let body = String(data: data ?? Data(), encoding: .utf8) ?? ""
                 DispatchQueue.main.async { self.errorMessage = "Resolve \(http.statusCode): \(body)" }
@@ -657,7 +657,7 @@ class HistoricalRaceViewModel: ObservableObject {
                 return
             }
 
-            var comps = URLComponents(string: "\(API.base)/api/live/resolve")!
+            var comps = URLComponents(string: "\(API.base)/api/historical/resolve")!
             comps.queryItems = [
                 URLQueryItem(name: "year", value: String(yearInt)),
                 URLQueryItem(name: "circuit_key", value: String(circuitKey)),
@@ -665,7 +665,7 @@ class HistoricalRaceViewModel: ObservableObject {
             ]
             let resolveURL = comps.url!
             URLSession.shared.dataTask(with: resolveURL) { data, resp, err in
-                self.log("GET /live/resolve", "url=\(resolveURL)\nerr=\(String(describing: err)) status=\((resp as? HTTPURLResponse)?.statusCode ?? -1)\n\(self.previewBody(data))")
+                self.log("GET /historical/resolve", "url=\(resolveURL)\nerr=\(String(describing: err)) status=\((resp as? HTTPURLResponse)?.statusCode ?? -1)\n\(self.previewBody(data))")
                 guard err == nil, let data = data, let session = try? JSONDecoder().decode(ResolveResponse.self, from: data) else {
                     DispatchQueue.main.async { self.diagnosisSummary = "resolve a eșuat. Vezi log." }
                     return


### PR DESCRIPTION
## Summary
- Route all OpenF1 calls through the local Laravel API
- Resolve historical sessions via `/api/historical/resolve`

## Testing
- `php artisan test` *(fails: SQLSTATE[HY000] [2002] Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68afa7614e948323ad11d43ecc0fd255