### PR TITLE
feat: support separate historical API base URL

### DIFF
--- a/F1App/F1App/API.swift
+++ b/F1App/F1App/API.swift
@@ -1,22 +1,19 @@
 import Foundation
 
-#if targetEnvironment(simulator)
-let baseURL = URL(string: "http://127.0.0.1:8000")!
-#else
-let baseURL = URL(string: "http://<IP_LAN_MAC>:8000")! // ex. 192.168.1.23
-#endif
-
 let openF1BaseURL = "https://api.openf1.org/v1"
 
 enum API {
     #if targetEnvironment(simulator)
     static let baseURL = URL(string: (ProcessInfo.processInfo.environment["API_BASE"] ?? "http://127.0.0.1:8000"))!
+    static let historicalBaseURL = URL(string: (ProcessInfo.processInfo.environment["HISTORICAL_API_BASE"] ?? baseURL.absoluteString))!
     #else
     static let baseURL = URL(string: (ProcessInfo.processInfo.environment["API_BASE"] ?? "http://192.168.X.Y:8000"))! // ← pune IP-ul LAN
+    static let historicalBaseURL = URL(string: (ProcessInfo.processInfo.environment["HISTORICAL_API_BASE"] ?? baseURL.absoluteString))!
     #endif
 
     // ✅ alias ca să nu mai dea "Type 'API' has no member 'base'"
     static var base: String { baseURL.absoluteString }
+    static var historicalBase: String { historicalBaseURL.absoluteString }
 
     static func url(_ path: String, query: [String:String]? = nil) -> URL {
         var comps = URLComponents(url: baseURL, resolvingAgainstBaseURL: false)!

--- a/F1App/F1App/HistoricalRaceViewModel.swift
+++ b/F1App/F1App/HistoricalRaceViewModel.swift
@@ -47,7 +47,7 @@ struct StrategyResponse: Decodable {
 }
 
 func loadStrategy(meeting: Int) async -> [StrategySuggestion] {
-    let url = baseURL.appendingPathComponent("/api/historical/meeting/\(meeting)/strategy")
+    let url = API.historicalBaseURL.appendingPathComponent("/api/historical/meeting/\(meeting)/strategy")
     do {
         let (data, resp) = try await URLSession.shared.data(from: url)
         let http = resp as! HTTPURLResponse

--- a/F1App/F1App/HistoricalStreamService.swift
+++ b/F1App/F1App/HistoricalStreamService.swift
@@ -65,7 +65,7 @@ final class HistoricalStreamService {
     private let baseURL: URL
     private let decoder: JSONDecoder
 
-    init(baseURL: String = API.base) {
+    init(baseURL: String = API.historicalBase) {
         self.baseURL = URL(string: baseURL)!
         let d = JSONDecoder()
         d.dateDecodingStrategy = .iso8601

--- a/F1App/Info.plist
+++ b/F1App/Info.plist
@@ -4,6 +4,8 @@
 <dict>
     <key>API_BASE_URL</key>
     <string>http://127.0.0.1:8000</string>
+    <key>HISTORICAL_API_BASE_URL</key>
+    <string>http://127.0.0.1:8000</string>
     <key>NSAppTransportSecurity</key>
     <dict>
         <key>NSAllowsLocalNetworking</key>

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 ## API Base URL
 
 The mobile app reads its server address from `F1App/Info.plist` (`API_BASE_URL`).
+Historical playback endpoints can override this via `HISTORICAL_API_BASE_URL`; if absent it defaults to `API_BASE_URL`.
 
 - **Simulator:** the default value `http://127.0.0.1:8000` points to a server running on the same machine.
 - **Physical device:** replace `API_BASE_URL` with your computer's IPv4 address on the local network (e.g. `http://192.168.0.10:8000`) so the device can reach the development server.
@@ -39,9 +40,9 @@ The new historical endpoints live under `/api/historical` and expose:
 
 ### iOS client
 
-Open `F1App/F1App.xcodeproj` in Xcode 15+. Ensure `API_BASE_URL` in `Info.plist`
-points to the backend server (see above). The client uses the new
-`HistoricalStreamService` to stream frames and `PlaybackViewModel` to
-control buffering and playback.
+Open `F1App/F1App.xcodeproj` in Xcode 15+. Ensure `API_BASE_URL` (and, if different,
+`HISTORICAL_API_BASE_URL`) in `Info.plist` point to the backend server (see above).
+The client uses the new `HistoricalStreamService` to stream frames and
+`PlaybackViewModel` to control buffering and playback.
 
 Run unit tests with `swift test` or the Xcode test action.


### PR DESCRIPTION
## Summary
- allow app to use distinct base URL for historical playback
- default HistoricalStreamService and strategy loading to new historical base
- document HISTORICAL_API_BASE_URL in Info.plist and README

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `php artisan test` *(fails: SQLSTATE[HY000] [2002] Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68afaa0800ec832383710c14df204a85