### PR TITLE
Throttle requests and handle OpenF1 HTTP errors

### DIFF
--- a/F1App/F1App/Utils/RequestThrottler.swift
+++ b/F1App/F1App/Utils/RequestThrottler.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+final class RequestThrottler {
+    static let shared = RequestThrottler(maxRequestsPerSecond: 3)
+
+    private let queue = DispatchQueue(label: "RequestThrottler")
+    private let interval: TimeInterval
+    private var lastRequest: Date = .distantPast
+
+    init(maxRequestsPerSecond: Int) {
+        interval = 1.0 / Double(maxRequestsPerSecond)
+    }
+
+    func execute(_ block: @escaping () -> Void) {
+        queue.async {
+            let now = Date()
+            let wait = self.lastRequest.addingTimeInterval(self.interval).timeIntervalSince(now)
+            if wait > 0 {
+                Thread.sleep(forTimeInterval: wait)
+            }
+            self.lastRequest = Date()
+            block()
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- inspect HTTP status codes in HistoricalRaceViewModel fetch helpers and log or retry on 429
- add simple RequestThrottler to keep API usage under 3 req/sec
- add retry logic to strategy fetch

## Testing
- `swift build` *(fails: Could not find Package.swift in this directory or any of its parent directories)*

------
https://chatgpt.com/codex/tasks/task_e_68b04aa974608323bf46e29958d12b09