### PR TITLE
Use OpenF1 session times for historical playback

### DIFF
--- a/F1App/F1App/API.swift
+++ b/F1App/F1App/API.swift
@@ -14,6 +14,7 @@ enum API {
     // ✅ alias ca să nu mai dea "Type 'API' has no member 'base'"
     static var base: String { baseURL.absoluteString }
     static var historicalBase: String { historicalBaseURL.absoluteString }
+    static var openF1Base: String { openF1BaseURL }
 
     static func url(_ path: String, query: [String:String]? = nil) -> URL {
         var comps = URLComponents(url: baseURL, resolvingAgainstBaseURL: false)!

--- a/F1App/F1App/Utils/RequestThrottler.swift
+++ b/F1App/F1App/Utils/RequestThrottler.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+final class RequestThrottler {
+    static let shared = RequestThrottler(maxRequestsPerSecond: 3)
+
+    private let queue = DispatchQueue(label: "RequestThrottler")
+    private let interval: TimeInterval
+    private var lastRequest: Date = .distantPast
+
+    init(maxRequestsPerSecond: Int) {
+        interval = 1.0 / Double(maxRequestsPerSecond)
+    }
+
+    func execute(_ block: @escaping () -> Void) {
+        queue.async {
+            let now = Date()
+            let wait = self.lastRequest.addingTimeInterval(self.interval).timeIntervalSince(now)
+            if wait > 0 {
+                Thread.sleep(forTimeInterval: wait)
+            }
+            self.lastRequest = Date()
+            block()
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- derive session start/end from OpenF1 /sessions API and store timezone-aware dates
- fetch location frames with inclusive time window and margin, probing when empty to expand window or report missing data
- expose openF1 base URL via API helper

## Testing
- `swift build` *(fails: Could not find Package.swift in this directory or any of its parent directories)*

------
https://chatgpt.com/codex/tasks/task_e_68b04aa974608323bf46e29958d12b09