### PR TITLE
Implement historical OpenF1 snapshot workflow

### DIFF
--- a/F1App/F1App/HistoricalSnapshotService.swift
+++ b/F1App/F1App/HistoricalSnapshotService.swift
@@ -1,0 +1,74 @@
+import Foundation
+
+struct OpenF1Session: Decodable {
+    let session_key: Int
+}
+
+struct LiveSnapshot: Decodable {
+    struct DriverState: Decodable {
+        struct Position: Decodable {
+            let position: Int?
+        }
+        struct Location: Decodable {
+            let x: Double?
+            let y: Double?
+        }
+
+        let driver_number: Int
+        let name_acronym: String?
+        let team_name: String?
+        let team_colour: String?
+        let position: Position?
+        let location: Location?
+
+        var name: String {
+            name_acronym ?? "Driver \(driver_number)"
+        }
+    }
+
+    let session_key: Int?
+    let ts: String?
+    let drivers: [DriverState]
+}
+
+class HistoricalSnapshotService {
+    func fetchSnapshot(year: Int, completion: @escaping (Result<LiveSnapshot, Error>) -> Void) {
+        guard let sessionsURL = URL(string: "\(openF1BaseURL)/sessions?year=\(year)&session_type=Race&limit=1") else {
+            completion(.failure(URLError(.badURL)))
+            return
+        }
+        URLSession.shared.dataTask(with: sessionsURL) { data, resp, err in
+            if let err = err {
+                completion(.failure(err))
+                return
+            }
+            guard let data = data,
+                  let session = try? JSONDecoder().decode([OpenF1Session].self, from: data).first else {
+                completion(.failure(URLError(.badServerResponse)))
+                return
+            }
+            let sessionKey = session.session_key
+            guard let snapshotURL = URL(string: "\(openF1BaseURL)/live/snapshot?session_key=\(sessionKey)") else {
+                completion(.failure(URLError(.badURL)))
+                return
+            }
+            URLSession.shared.dataTask(with: snapshotURL) { data, resp, err in
+                if let err = err {
+                    completion(.failure(err))
+                    return
+                }
+                guard let data = data else {
+                    completion(.failure(URLError(.badServerResponse)))
+                    return
+                }
+                do {
+                    let snapshot = try JSONDecoder().decode(LiveSnapshot.self, from: data)
+                    completion(.success(snapshot))
+                } catch {
+                    completion(.failure(error))
+                }
+            }.resume()
+        }.resume()
+    }
+}
+


### PR DESCRIPTION
## Summary
- add service to fetch session and snapshot data from OpenF1 for historical sessions
- integrate snapshot flow into HistoricalRaceViewModel for processing driver positions

## Testing
- `swift build` *(fails: Could not find Package.swift)*
- `cd ../API/F1_API && phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b05d055fc483239d652fecd8c093e2