### PR TITLE
Route historical flow through Laravel API

### DIFF
--- a/F1App/F1App/HistoricalSnapshotService.swift
+++ b/F1App/F1App/HistoricalSnapshotService.swift
@@ -1,12 +1,5 @@
 import Foundation
 
-struct OpenF1Session: Decodable {
-    let session_key: Int
-    let meeting_key: Int?
-    let date_start: String?
-    let date_end: String?
-}
-
 struct LiveSnapshot: Decodable {
     struct DriverState: Decodable {
         struct Position: Decodable {
@@ -46,7 +39,7 @@ class HistoricalSnapshotService {
                 return
             }
             guard let data = data,
-                  let session = try? JSONDecoder().decode([OpenF1Session].self, from: data).first else {
+                  let session = try? JSONDecoder().decode(Envelope<[SessionDTO]>.self, from: data).data.last else {
                 completion(.failure(URLError(.badServerResponse)))
                 return
             }


### PR DESCRIPTION
## Summary
- wrap Laravel responses in `Envelope` and decode via new `fetchEnvelope`
- resolve sessions and build location windows using local session dates with GMT offsets
- proxy historical snapshot and location queries through Laravel endpoints with fallback probing

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68b0d34743408323aa0ebc4267518cb1