### PR TITLE
Fetch historical session by circuit and year

### DIFF
--- a/F1App/F1App/HistoricalRaceViewModel.swift
+++ b/F1App/F1App/HistoricalRaceViewModel.swift
@@ -771,8 +771,8 @@ class HistoricalRaceViewModel: ObservableObject {
         }.resume()
     }
 
-    func loadSnapshot(forYear year: Int) {
-        snapshotService.fetchSnapshot(year: year) { result in
+    func loadSnapshot(forYear year: Int, circuitKey: Int) {
+        snapshotService.fetchSnapshot(year: year, circuitKey: circuitKey) { result in
             DispatchQueue.main.async {
                 switch result {
                 case .success(let snap):

--- a/F1App/F1App/HistoricalSnapshotService.swift
+++ b/F1App/F1App/HistoricalSnapshotService.swift
@@ -32,8 +32,14 @@ struct LiveSnapshot: Decodable {
 }
 
 class HistoricalSnapshotService {
-    func fetchSnapshot(year: Int, completion: @escaping (Result<LiveSnapshot, Error>) -> Void) {
-        guard let sessionsURL = URL(string: "\(openF1BaseURL)/sessions?year=\(year)&session_type=Race&limit=1") else {
+    func fetchSnapshot(year: Int, circuitKey: Int, completion: @escaping (Result<LiveSnapshot, Error>) -> Void) {
+        var comps = URLComponents(string: "\(API.base)/api/openf1/sessions")
+        comps?.queryItems = [
+            URLQueryItem(name: "circuit_key", value: String(circuitKey)),
+            URLQueryItem(name: "session_name", value: "Race"),
+            URLQueryItem(name: "year", value: String(year))
+        ]
+        guard let sessionsURL = comps?.url else {
             completion(.failure(URLError(.badURL)))
             return
         }
@@ -48,7 +54,9 @@ class HistoricalSnapshotService {
                 return
             }
             let sessionKey = session.session_key
-            guard let snapshotURL = URL(string: "\(openF1BaseURL)/live/snapshot?session_key=\(sessionKey)") else {
+            var snapComps = URLComponents(string: "\(API.base)/api/live/snapshot")
+            snapComps?.queryItems = [URLQueryItem(name: "session_key", value: String(sessionKey))]
+            guard let snapshotURL = snapComps?.url else {
                 completion(.failure(URLError(.badURL)))
                 return
             }


### PR DESCRIPTION
## Summary
- Resolve historical session using circuit_key and year before fetching live snapshot
- Allow `HistoricalRaceViewModel` to request snapshots with circuit information

## Testing
- `swiftc -typecheck F1App/F1App/HistoricalSnapshotService.swift` *(fails: cannot find 'API' in scope; type 'URLSession' has no member 'shared')*
- `swift --version`


------
https://chatgpt.com/codex/tasks/task_e_68b0edcd576c8323b907b9ef65dffd20