### PR TITLE
Fetch historical snapshot before resolving session

### DIFF
--- a/F1App/F1App/HistoricalRaceViewModel.swift
+++ b/F1App/F1App/HistoricalRaceViewModel.swift
@@ -195,6 +195,9 @@ class HistoricalRaceViewModel: ObservableObject {
             return
         }
 
+        // Încarcă snapshot-ul istoric bazat pe anul și circuitul selectat
+        loadSnapshot(forYear: yearInt, circuitKey: circuitKey)
+
         // Rezolvă sesiunea DOAR cu year + circuit_key
         resolveSession(year: yearInt, meetingKey: nil, circuitKey: circuitKey)
     }
@@ -777,6 +780,9 @@ class HistoricalRaceViewModel: ObservableObject {
                 switch result {
                 case .success(let snap):
                     self.snapshot = snap
+                    if let key = snap.session_key {
+                        self.sessionKey = key
+                    }
                     self.drivers = snap.drivers.map {
                         DriverInfo(driver_number: $0.driver_number,
                                    full_name: $0.name,


### PR DESCRIPTION
## Summary
- fetch historical snapshot using circuit and year before resolving session
- store session key from snapshot in view model

## Testing
- `swift test` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*
- `xcodebuild -version` *(fails: command not found: xcodebuild)*

------
https://chatgpt.com/codex/tasks/task_e_68b0f6d38d508323bde8e0a6325780cb