### PR TITLE
Add upcoming race background and red bar styling

### DIFF
--- a/F1App/F1App/CountdownView.swift
+++ b/F1App/F1App/CountdownView.swift
@@ -6,21 +6,38 @@ struct CountdownView: View {
     private let timer = Timer.publish(every: 1, on: .main, in: .common).autoconnect()
 
     var body: some View {
-        Text(formattedTime)
-            .font(.largeTitle)
-            .padding()
-            .background(Color.red)
-            .cornerRadius(8)
-            .foregroundColor(.white)
-            .onReceive(timer) { _ in updateTime() }
-            .onAppear { updateTime() }
+        HStack(spacing: 8) {
+            timeBox(value: components.days, label: "Zile")
+            timeBox(value: components.hours, label: "Ore")
+            timeBox(value: components.minutes, label: "Minute")
+        }
+        .onReceive(timer) { _ in updateTime() }
+        .onAppear { updateTime() }
     }
 
-    private var formattedTime: String {
+    private func timeBox(value: Int, label: String) -> some View {
+        VStack {
+            Text(String(format: "%02d", value))
+                .font(.title2)
+                .bold()
+            Text(label)
+                .font(.caption)
+        }
+        .padding(6)
+        .background(Color.white)
+        .overlay(
+            RoundedRectangle(cornerRadius: 6)
+                .stroke(Color.black, lineWidth: 2)
+        )
+        .foregroundColor(.black)
+    }
+
+    private var components: (days: Int, hours: Int, minutes: Int) {
         let total = max(Int(timeRemaining), 0)
-        let hours = total / 3600
-        let minutes = (total % 3600) / 60
-        return String(format: "%02dh %02dm", hours, minutes)
+        let days = total / 86_400
+        let hours = (total % 86_400) / 3_600
+        let minutes = (total % 3_600) / 60
+        return (days, hours, minutes)
     }
 
     private func updateTime() {

--- a/F1App/F1App/F1AppApp.swift
+++ b/F1App/F1App/F1AppApp.swift
@@ -6,11 +6,34 @@
 //
 
 import SwiftUI
+import UIKit
 
 @main
 struct F1AppApp: App {
     @State private var showSplash = true
     @StateObject private var teamColorStore = TeamColorStore()
+
+    init() {
+        let color = UIColor(Color(hex: "ce2d1e"))
+
+        let navAppearance = UINavigationBarAppearance()
+        navAppearance.configureWithOpaqueBackground()
+        navAppearance.backgroundColor = color
+        navAppearance.titleTextAttributes = [.foregroundColor: UIColor.white]
+        navAppearance.largeTitleTextAttributes = [.foregroundColor: UIColor.white]
+        UINavigationBar.appearance().standardAppearance = navAppearance
+        UINavigationBar.appearance().scrollEdgeAppearance = navAppearance
+        UINavigationBar.appearance().tintColor = .white
+
+        let tabAppearance = UITabBarAppearance()
+        tabAppearance.configureWithOpaqueBackground()
+        tabAppearance.backgroundColor = color
+        UITabBar.appearance().standardAppearance = tabAppearance
+        if #available(iOS 15.0, *) {
+            UITabBar.appearance().scrollEdgeAppearance = tabAppearance
+        }
+        UITabBar.appearance().tintColor = .white
+    }
 
     var body: some Scene {
         WindowGroup {

--- a/F1App/F1App/RaceDetailView.swift
+++ b/F1App/F1App/RaceDetailView.swift
@@ -27,16 +27,26 @@ struct RaceDetailView: View {
             Spacer()
 
             if selectedTab == 0 {
-                if race.status.lowercased() == "finished" {
-                    RaceResultsView(race: race, viewModel: viewModel)
-                        .padding()
-                } else {
-                    CircuitView(coordinatesJSON: race.coordinates, viewModel: viewModel)
-                        .frame(height: UIScreen.main.bounds.height / 2)
-                        .padding()
+                ZStack {
                     if isUpcomingRace {
-                        CountdownView(dateString: race.date)
+                        Image("nahuui")
+                            .resizable()
+                            .scaledToFill()
+                            .ignoresSafeArea()
+                    }
+                    if race.status.lowercased() == "finished" {
+                        RaceResultsView(race: race, viewModel: viewModel)
                             .padding()
+                    } else {
+                        VStack {
+                            CircuitView(coordinatesJSON: race.coordinates, viewModel: viewModel)
+                                .frame(height: UIScreen.main.bounds.height / 2)
+                                .padding()
+                            if isUpcomingRace {
+                                CountdownView(dateString: race.date)
+                                    .padding()
+                            }
+                        }
                     }
                 }
             } else if selectedTab == 1 {


### PR DESCRIPTION
## Summary
- show days, hours, and minutes with black-outlined boxes in countdown
- display upcoming race circuit over `nahuui` background image
- apply global #ce2d1e color to navigation and tab bars

## Testing
- `swift test` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*

------
https://chatgpt.com/codex/tasks/task_e_68b195f9d24083238869c01851a05a57