### PR TITLE
style: apply red theme and simplify tab bar

### DIFF
--- a/F1App/F1App/ LoginView.swift
+++ b/F1App/F1App/ LoginView.swift
@@ -138,11 +138,6 @@ struct DashboardView: View {
                     Label("Acasă", systemImage: "house.fill")
                 }
 
-            DriversView()
-                .tabItem {
-                    Label("Piloți", systemImage: "person.3.fill")
-                }
-
             StandingsView()
                 .tabItem {
                     Label("Clasament", systemImage: "list.number")
@@ -159,6 +154,7 @@ struct DashboardView: View {
                 }
              //   .navigationBarBackButtonHidden(false)
         }
+        .tint(.white)
     }
 }
 

--- a/F1App/F1App/Color+Hex.swift
+++ b/F1App/F1App/Color+Hex.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import UIKit
 
 extension Color {
     init(hex: String) {
@@ -9,5 +10,17 @@ extension Color {
         let g = Double((int >> 8) & 0xFF) / 255.0
         let b = Double(int & 0xFF) / 255.0
         self.init(red: r, green: g, blue: b)
+    }
+}
+
+extension UIColor {
+    convenience init(hex: String) {
+        var hex = hex.trimmingCharacters(in: CharacterSet.alphanumerics.inverted)
+        var int: UInt64 = 0
+        Scanner(string: hex).scanHexInt64(&int)
+        let r = CGFloat((int >> 16) & 0xFF) / 255.0
+        let g = CGFloat((int >> 8) & 0xFF) / 255.0
+        let b = CGFloat(int & 0xFF) / 255.0
+        self.init(red: r, green: g, blue: b, alpha: 1)
     }
 }

--- a/F1App/F1App/F1AppApp.swift
+++ b/F1App/F1App/F1AppApp.swift
@@ -6,11 +6,37 @@
 //
 
 import SwiftUI
+import UIKit
 
 @main
 struct F1AppApp: App {
     @State private var showSplash = true
     @StateObject private var teamColorStore = TeamColorStore()
+
+    init() {
+        let themeColor = UIColor(hex: "ce2d1e")
+
+        // Navigation bar styling
+        let navAppearance = UINavigationBarAppearance()
+        navAppearance.configureWithOpaqueBackground()
+        navAppearance.backgroundColor = themeColor
+        navAppearance.titleTextAttributes = [.foregroundColor: UIColor.white]
+        navAppearance.largeTitleTextAttributes = [.foregroundColor: UIColor.white]
+        UINavigationBar.appearance().standardAppearance = navAppearance
+        UINavigationBar.appearance().scrollEdgeAppearance = navAppearance
+        UINavigationBar.appearance().compactAppearance = navAppearance
+        UINavigationBar.appearance().barTintColor = themeColor
+        UINavigationBar.appearance().tintColor = .white
+
+        // Tab bar styling
+        let tabAppearance = UITabBarAppearance()
+        tabAppearance.configureWithOpaqueBackground()
+        tabAppearance.backgroundColor = themeColor
+        UITabBar.appearance().standardAppearance = tabAppearance
+        UITabBar.appearance().scrollEdgeAppearance = tabAppearance
+        UITabBar.appearance().barTintColor = themeColor
+        UITabBar.appearance().tintColor = .white
+    }
 
     var body: some Scene {
         WindowGroup {
@@ -25,6 +51,7 @@ struct F1AppApp: App {
                     .transition(.opacity)
                 }
             }
+            .background(Color.black.ignoresSafeArea())
             .environmentObject(teamColorStore)
         }
     }


### PR DESCRIPTION
## Summary
- style nav and tab bars with F1 red theme and white icons
- show black status/home bars across the app
- remove Pilots tab from the dashboard

## Testing
- `xcodebuild -scheme F1App -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 14' build` *(fails: command not found)*
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68b197e4ba408323b9a79e4a213144fc