### PR TITLE
Shrink navigation bar across app

### DIFF
--- a/F1App/F1App/DriversView.swift
+++ b/F1App/F1App/DriversView.swift
@@ -20,6 +20,7 @@ struct DriversView: View {
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .background(AppColors.bg)
             .navigationTitle("Piloți")
+            .navigationBarTitleDisplayMode(.inline)
             .background(AppColors.bg.ignoresSafeArea())
         }
     }

--- a/F1App/F1App/F1AppApp.swift
+++ b/F1App/F1App/F1AppApp.swift
@@ -27,6 +27,7 @@ struct F1AppApp: App {
         UINavigationBar.appearance().compactAppearance = navAppearance
         UINavigationBar.appearance().barTintColor = themeColor
         UINavigationBar.appearance().tintColor = .white
+        UINavigationBar.appearance().prefersLargeTitles = false
 
         // Tab bar styling
         let tabAppearance = UITabBarAppearance()

--- a/F1App/F1App/HomeView.swift
+++ b/F1App/F1App/HomeView.swift
@@ -43,6 +43,7 @@ struct HomeView: View {
             }
             .listStyle(.plain)
             .navigationTitle("Acasă")
+            .navigationBarTitleDisplayMode(.inline)
             .task { await viewModel.load() }
             .refreshable { await viewModel.load() }
             .navigationDestination(item: $selectedItem) { item in

--- a/F1App/F1App/ProfileView.swift
+++ b/F1App/F1App/ProfileView.swift
@@ -93,6 +93,7 @@ struct ProfileView: View {
                 }
             }
             .navigationTitle("Profil")
+            .navigationBarTitleDisplayMode(.inline)
         }
     }
     

--- a/F1App/F1App/RacesView.swift
+++ b/F1App/F1App/RacesView.swift
@@ -24,6 +24,7 @@ struct RacesView: View {
                 }
             }
             .navigationTitle("F1 Circuits")
+            .navigationBarTitleDisplayMode(.inline)
             .onAppear {
                 viewModel.fetchRaces()
             }


### PR DESCRIPTION
## Summary
- disable large titles globally so navigation bars use compact height
- set inline title display mode in core views for a smaller nav bar

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68b19a117aac83238cd60d9900b200df