### PR TITLE
Increase font size of F1 news header

### DIFF
--- a/F1App/F1App/HomeView.swift
+++ b/F1App/F1App/HomeView.swift
@@ -14,7 +14,7 @@ struct HomeView: View {
     var body: some View {
         NavigationStack {
             List {
-                Section("Știri F1 (Autosport)") {
+                Section {
                     if viewModel.isLoading {
                         ProgressView().frame(maxWidth: .infinity)
                     } else if let error = viewModel.error {
@@ -39,6 +39,9 @@ struct HomeView: View {
                                 .frame(maxWidth: .infinity)
                         }
                     }
+                } header: {
+                    Text("Știri F1 (Autosport)")
+                        .font(.title2)
                 }
             }
             .listStyle(.plain)


### PR DESCRIPTION
## Summary
- Make "Știri F1 (Autosport)" section header larger using `.font(.title2)` in HomeView

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b19b2052bc8323b8017aaafc86fa26