### PR TITLE
Improve upcoming race countdown

### DIFF
--- a/F1App/F1App/CountdownView.swift
+++ b/F1App/F1App/CountdownView.swift
@@ -7,20 +7,22 @@ struct CountdownView: View {
 
     var body: some View {
         Text(formattedTime)
-            .font(.largeTitle)
+            .font(.custom("New York", size: 34))
             .padding()
-            .background(Color.red)
-            .cornerRadius(8)
-            .foregroundColor(.white)
+            .overlay(
+                RoundedRectangle(cornerRadius: 8)
+                    .stroke(Color.black, lineWidth: 2)
+            )
             .onReceive(timer) { _ in updateTime() }
             .onAppear { updateTime() }
     }
 
     private var formattedTime: String {
         let total = max(Int(timeRemaining), 0)
-        let hours = total / 3600
-        let minutes = (total % 3600) / 60
-        return String(format: "%02dh %02dm", hours, minutes)
+        let days = total / 86_400
+        let hours = (total % 86_400) / 3_600
+        let minutes = (total % 3_600) / 60
+        return String(format: "%dd %02dh %02dm", days, hours, minutes)
     }
 
     private func updateTime() {

--- a/F1App/F1App/RaceDetailView.swift
+++ b/F1App/F1App/RaceDetailView.swift
@@ -35,8 +35,12 @@ struct RaceDetailView: View {
                         .frame(height: UIScreen.main.bounds.height / 2)
                         .padding()
                     if isUpcomingRace {
-                        CountdownView(dateString: race.date)
-                            .padding()
+                        VStack(spacing: 4) {
+                            Text("START IN")
+                                .font(.custom("New York", size: 17))
+                            CountdownView(dateString: race.date)
+                        }
+                        .padding()
                     }
                 }
             } else if selectedTab == 1 {


### PR DESCRIPTION
## Summary
- show upcoming race countdown with days, hours and minutes
- outline countdown with a black border
- display "START IN" label above countdown in circuit view
- render countdown and label with New York font

## Testing
- `swift build` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*


------
https://chatgpt.com/codex/tasks/task_e_68b19ea8b4b48323bd367ede6bb90e90