### PR TITLE
Refine countdown timer styling

### DIFF
--- a/F1App/F1App/CountdownView.swift
+++ b/F1App/F1App/CountdownView.swift
@@ -7,8 +7,11 @@ struct CountdownView: View {
 
     var body: some View {
         Text(formattedTime)
-            .font(.largeTitle)
+            .font(.custom("New York", size: 34))
             .padding()
+            .background(Color.red)
+            .foregroundColor(.white)
+            .cornerRadius(8)
             .overlay(
                 RoundedRectangle(cornerRadius: 8)
                     .stroke(Color.black, lineWidth: 2)

--- a/F1App/F1App/RaceDetailView.swift
+++ b/F1App/F1App/RaceDetailView.swift
@@ -37,7 +37,7 @@ struct RaceDetailView: View {
                     if isUpcomingRace {
                         VStack(spacing: 4) {
                             Text("START IN")
-                                .font(.headline)
+                                .font(.custom("New York", size: 17))
                             CountdownView(dateString: race.date)
                         }
                         .padding()


### PR DESCRIPTION
## Summary
- Style countdown timer with custom font, red background, and white text
- Show "START IN" label with custom font before countdown in race details

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68b1a15afae08323a879fab82dd351b5