### PR TITLE
Style upcoming race circuit

### DIFF
--- a/F1App/F1App/CircuitView.swift
+++ b/F1App/F1App/CircuitView.swift
@@ -10,6 +10,9 @@ import SwiftUI
 struct CircuitView: View {
     let coordinatesJSON: String?
     @ObservedObject var viewModel: HistoricalRaceViewModel
+    let lineColor: Color
+    let lineWidth: CGFloat
+    let sizeScale: CGFloat
     struct DriverSelection: Identifiable {
         let driver: DriverInfo
         let point: LocationPoint
@@ -17,9 +20,18 @@ struct CircuitView: View {
     }
     @State private var selectedDriver: DriverSelection?
 
-    init(coordinatesJSON: String?, viewModel: HistoricalRaceViewModel) {
+    init(
+        coordinatesJSON: String?,
+        viewModel: HistoricalRaceViewModel,
+        lineColor: Color = .white,
+        lineWidth: CGFloat = 4,
+        sizeScale: CGFloat = 1.0
+    ) {
         self.coordinatesJSON = coordinatesJSON
         self.viewModel = viewModel
+        self.lineColor = lineColor
+        self.lineWidth = lineWidth
+        self.sizeScale = sizeScale
     }
 
     // Determine track points either from view model or by parsing JSON
@@ -58,7 +70,7 @@ struct CircuitView: View {
             if points.isEmpty {
                 Text("No coordinates available").foregroundColor(.red)
             } else {
-                let size = min(geo.size.width, geo.size.height)
+                let size = min(geo.size.width, geo.size.height) * sizeScale
                 let xOffset = (geo.size.width - size) / 2
                 let yOffset = (geo.size.height - size) / 2
 
@@ -71,7 +83,7 @@ struct CircuitView: View {
                         }
                         path.closeSubpath()
                     }
-                    .stroke(Color.white, lineWidth: 4)
+                    .stroke(lineColor, lineWidth: lineWidth)
 
                     ForEach(viewModel.drivers) { driver in
                         if let loc = viewModel.currentPosition[driver.driver_number] {

--- a/F1App/F1App/RaceDetailView.swift
+++ b/F1App/F1App/RaceDetailView.swift
@@ -38,7 +38,13 @@ struct RaceDetailView: View {
                                 .scaledToFill()
                                 .clipped()
                         }
-                        CircuitView(coordinatesJSON: race.coordinates, viewModel: viewModel)
+                        CircuitView(
+                            coordinatesJSON: race.coordinates,
+                            viewModel: viewModel,
+                            lineColor: isUpcomingRace ? Color(hex: "ce2d1e") : .white,
+                            lineWidth: isUpcomingRace ? 6 : 4,
+                            sizeScale: isUpcomingRace ? 0.9 : 1.0
+                        )
                     }
                     .frame(height: UIScreen.main.bounds.height / 2)
                     .padding()


### PR DESCRIPTION
## Summary
- Allow customizing circuit path rendering through color, line width, and size scaling
- Style upcoming race circuit with thicker #ce2d1e path and slightly reduced size

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68b1a776dfec832392b1953afdc462f3