### PR TITLE
Fade edges of upcoming race background image

### DIFF
--- a/F1App/F1App/RaceDetailView.swift
+++ b/F1App/F1App/RaceDetailView.swift
@@ -36,6 +36,14 @@ struct RaceDetailView: View {
                             Image("nahuui")
                                 .resizable()
                                 .scaledToFill()
+                                .overlay(
+                                    RadialGradient(
+                                        gradient: Gradient(colors: [Color.white.opacity(0), Color.white.opacity(0.6)]),
+                                        center: .center,
+                                        startRadius: 0,
+                                        endRadius: UIScreen.main.bounds.width
+                                    )
+                                )
                                 .clipped()
                         }
                         CircuitView(


### PR DESCRIPTION
## Summary
- add radial gradient overlay so upcoming race background images fade near the edges for a softer look

## Testing
- `cd F1App && swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68b1a92218cc8323b59d96c8c1ef6107