### PR TITLE
Dark background for upcoming circuit view

### DIFF
--- a/F1App/F1App/CircuitView.swift
+++ b/F1App/F1App/CircuitView.swift
@@ -13,6 +13,7 @@ struct CircuitView: View {
     let lineColor: Color
     let lineWidth: CGFloat
     let sizeScale: CGFloat
+    let backgroundColor: Color
     struct DriverSelection: Identifiable {
         let driver: DriverInfo
         let point: LocationPoint
@@ -25,13 +26,15 @@ struct CircuitView: View {
         viewModel: HistoricalRaceViewModel,
         lineColor: Color = .white,
         lineWidth: CGFloat = 4,
-        sizeScale: CGFloat = 1.0
+        sizeScale: CGFloat = 1.0,
+        backgroundColor: Color = Color.gray.opacity(0.1)
     ) {
         self.coordinatesJSON = coordinatesJSON
         self.viewModel = viewModel
         self.lineColor = lineColor
         self.lineWidth = lineWidth
         self.sizeScale = sizeScale
+        self.backgroundColor = backgroundColor
     }
 
     // Determine track points either from view model or by parsing JSON
@@ -110,7 +113,7 @@ struct CircuitView: View {
                     }
                 }
                 .animation(.linear(duration: 1), value: viewModel.stepIndex)
-                .background(Color.gray.opacity(0.1))
+                .background(backgroundColor)
                 .cornerRadius(8)
                 .sheet(item: $selectedDriver) { selection in
                     if let sk = viewModel.sessionKey {

--- a/F1App/F1App/RaceDetailView.swift
+++ b/F1App/F1App/RaceDetailView.swift
@@ -51,7 +51,8 @@ struct RaceDetailView: View {
                             viewModel: viewModel,
                             lineColor: isUpcomingRace ? Color(hex: "ce2d1e") : .white,
                             lineWidth: isUpcomingRace ? 6 : 4,
-                            sizeScale: isUpcomingRace ? 0.9 : 1.0
+                            sizeScale: isUpcomingRace ? 0.9 : 1.0,
+                            backgroundColor: isUpcomingRace ? Color(hex: "37373d") : Color.gray.opacity(0.1)
                         )
                     }
                     .frame(height: UIScreen.main.bounds.height / 2)


### PR DESCRIPTION
## Summary
- Allow configuring CircuitView's background color
- Use dark gray background (#37373d) when race is upcoming

## Testing
- `swift test` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*

------
https://chatgpt.com/codex/tasks/task_e_68b1abfb76e4832391522d83fc19aa49