### PR TITLE
Use dark background for upcoming race circuit

### DIFF
--- a/F1App/F1App/RaceDetailView.swift
+++ b/F1App/F1App/RaceDetailView.swift
@@ -45,22 +45,23 @@ struct RaceDetailView: View {
                                     )
                                 )
                                 .clipped()
-                        }
-                        CircuitView(
-                            coordinatesJSON: race.coordinates,
-                            viewModel: viewModel,
-                            lineColor: isUpcomingRace ? Color(hex: "ce2d1e") : .white,
-                            lineWidth: isUpcomingRace ? 6 : 4,
-                            sizeScale: isUpcomingRace ? 0.9 : 1.0,
-                            backgroundColor: isUpcomingRace ? Color(hex: "37373d") : Color.gray.opacity(0.1)
-                        )
                     }
-                    .frame(height: UIScreen.main.bounds.height / 2)
-                    .padding()
-                    if isUpcomingRace {
-                        VStack(spacing: 4) {
-                            Text("START IN")
-                                .font(.headline)
+                    CircuitView(
+                        coordinatesJSON: race.coordinates,
+                        viewModel: viewModel,
+                        lineColor: isUpcomingRace ? Color(hex: "ce2d1e") : .white,
+                        lineWidth: isUpcomingRace ? 6 : 4,
+                        sizeScale: isUpcomingRace ? 0.9 : 1.0,
+                        backgroundColor: isUpcomingRace ? Color(hex: "37373d") : Color.gray.opacity(0.1)
+                    )
+                }
+                .frame(height: UIScreen.main.bounds.height / 2)
+                .background(isUpcomingRace ? Color(hex: "37373d") : Color.clear)
+                .padding()
+                if isUpcomingRace {
+                    VStack(spacing: 4) {
+                        Text("START IN")
+                            .font(.headline)
                             CountdownView(dateString: race.date)
                         }
                         .padding()


### PR DESCRIPTION
## Summary
- Darken circuit background for upcoming races

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68b1ad0f9b2883239a7a0786f1c25eb8