### PR TITLE
Render historical race circuit in black with thicker line

### DIFF
--- a/F1App/F1App/HistoricalRaceView.swift
+++ b/F1App/F1App/HistoricalRaceView.swift
@@ -51,7 +51,7 @@ struct HistoricalRaceView: View {
                             }
                             path.closeSubpath()
                         }
-                        .stroke(Color.blue, lineWidth: 2)
+                        .stroke(Color.black, lineWidth: 4)
 
                         if !viewModel.currentPosition.isEmpty {
                             ForEach(viewModel.drivers) { driver in


### PR DESCRIPTION
## Summary
- draw historical race circuit in black
- increase circuit line width for better visibility

## Testing
- `swift build` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*

------
https://chatgpt.com/codex/tasks/task_e_68b1b214330c83239015e56976dbcbbb