### PR TITLE
Show team logos in team standings

### DIFF
--- a/F1App/F1App/Image+Team.swift
+++ b/F1App/F1App/Image+Team.swift
@@ -1,0 +1,19 @@
+import SwiftUI
+import UIKit
+
+extension Image {
+    /// Loads a team logo from the asset catalog using the team name.
+    /// - Parameter teamName: The official team name (e.g., "Ferrari").
+    /// - Returns: Image of the team logo or a default placeholder if not found.
+    static func teamLogo(for teamName: String) -> Image {
+        let base = teamName
+            .lowercased()
+            .replacingOccurrences(of: " ", with: "")
+        let assetName = "2025\(base)logo"
+        if let uiImage = UIImage(named: assetName) {
+            return Image(uiImage: uiImage)
+        }
+        return Image(systemName: "questionmark")
+    }
+}
+

--- a/F1App/F1App/StandingsView.swift
+++ b/F1App/F1App/StandingsView.swift
@@ -1,9 +1,10 @@
 import SwiftUI
 
 struct StandingsView: View {
+    @EnvironmentObject var colorStore: TeamColorStore
     @State private var standings: [DriverStanding] = []
     @State private var selectedTab: String = "Piloți"
-    
+
     var body: some View {
         NavigationView {
             VStack (spacing: 0){
@@ -41,11 +42,23 @@ struct StandingsView: View {
                         }
                     } else {
                         ForEach(teamStandings(), id: \.team) { teamStanding in
-                            VStack(alignment: .leading) {
-                                Text(teamStanding.team)
-                                    .font(.headline)
-                                Text("Puncte: \(teamStanding.points)")
-                                    .font(.subheadline)
+                            HStack {
+                                VStack(alignment: .leading) {
+                                    Text(teamStanding.team)
+                                        .font(.headline)
+                                    Text("Puncte: \(teamStanding.points)")
+                                        .font(.subheadline)
+                                }
+                                Spacer()
+                                Circle()
+                                    .fill(colorStore.color(forTeamName: teamStanding.team))
+                                    .frame(width: 40, height: 40)
+                                    .overlay(
+                                        Image.teamLogo(for: teamStanding.team)
+                                            .resizable()
+                                            .scaledToFit()
+                                            .padding(6)
+                                    )
                             }
                             .padding(.vertical, 4)
                         }


### PR DESCRIPTION
## Summary
- display team logos with colored circle in team standings
- add helper to load team logos by team name

## Testing
- `swift test` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*


------
https://chatgpt.com/codex/tasks/task_e_68b1d97de68483238d8d70a622915ebc