### PR TITLE
Show team logos in standings

### DIFF
--- a/F1App/F1App/StandingsView.swift
+++ b/F1App/F1App/StandingsView.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 
 struct StandingsView: View {
+    @EnvironmentObject var colorStore: TeamColorStore
     @State private var standings: [DriverStanding] = []
     @State private var selectedTab: String = "Piloți"
     
@@ -41,11 +42,23 @@ struct StandingsView: View {
                         }
                     } else {
                         ForEach(teamStandings(), id: \.team) { teamStanding in
-                            VStack(alignment: .leading) {
-                                Text(teamStanding.team)
-                                    .font(.headline)
-                                Text("Puncte: \(teamStanding.points)")
-                                    .font(.subheadline)
+                            HStack {
+                                VStack(alignment: .leading) {
+                                    Text(teamStanding.team)
+                                        .font(.headline)
+                                    Text("Puncte: \(teamStanding.points)")
+                                        .font(.subheadline)
+                                }
+                                Spacer()
+                                Circle()
+                                    .fill(colorStore.color(forTeamName: teamStanding.team))
+                                    .frame(width: 40, height: 40)
+                                    .overlay(
+                                        Image(teamLogoName(for: teamStanding.team))
+                                            .resizable()
+                                            .scaledToFit()
+                                            .padding(6)
+                                    )
                             }
                             .padding(.vertical, 4)
                         }
@@ -77,6 +90,14 @@ struct StandingsView: View {
             TeamStanding(team: team, points: drivers.reduce(0) { $0 + $1.points })
         }
         return teamStandings.sorted { $0.points > $1.points }
+    }
+
+    private func teamLogoName(for team: String) -> String {
+        let cleaned = team
+            .lowercased()
+            .replacingOccurrences(of: " ", with: "")
+            .replacingOccurrences(of: "-", with: "")
+        return "2025\(cleaned)logo"
     }
     
 }


### PR DESCRIPTION
## Summary
- Display constructor logos in team standings with colored circular backgrounds
- Map team names to corresponding logo assets

## Testing
- `cd F1App && swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68b1db996acc8323b24a1f62ba82de35